### PR TITLE
[cmake]-Added dependency to ensure flang_shared is build after flang_…

### DIFF
--- a/runtime/flang/CMakeLists.txt
+++ b/runtime/flang/CMakeLists.txt
@@ -577,7 +577,8 @@ add_dependencies(flang_static
   )
 
 # Make sure the compiler is built before we bootstrap
-add_dependencies(flang_shared 
+add_dependencies(flang_shared
+  flang_static 
   flang1
   flang2
   )


### PR DESCRIPTION
…static to avoid the modules are corrupt or out of date build error. It seems the issue was when these were building in parallel.