### PR TITLE
Change NATIVE_COMMAND to UNIX_COMMAND. Since NATIVE_COMMAND is not in…

### DIFF
--- a/runtime/flang/CMakeLists.txt
+++ b/runtime/flang/CMakeLists.txt
@@ -419,7 +419,7 @@ SET(FTN_SUPPORT_DESC_DEP
   )
 
 set(I8_FILES_DIR I8_sources)
-separate_arguments(SEPARATED_CMAKE_Fortran_FLAGS NATIVE_COMMAND ${CMAKE_Fortran_FLAGS})
+separate_arguments(SEPARATED_CMAKE_Fortran_FLAGS UNIX_COMMAND ${CMAKE_Fortran_FLAGS})
 
 if(EXISTS bin/flang1)
   set(FLANG1_DEP bin/flang1)


### PR DESCRIPTION
… 3.5.2 used in Jenkins.

Backported from rocmaster branch.