### PR TITLE
Flang debuggability patch2

### DIFF
--- a/test/debug_info/dwarfdump_prolog.f90
+++ b/test/debug_info/dwarfdump_prolog.f90
@@ -1,0 +1,30 @@
+!RUN: %flang -g %s -o %t
+!RUN: llvm-dwarfdump  --debug-line %t -o - | FileCheck %s
+
+!CHECK: name: "dwarfdump_prolog.f90"
+!CHECK: Address            Line   Column File   ISA Discriminator Flags
+!CHECK: {{0x[0-9a-f]+}}     13      1      1   0             0  is_stmt prologue_end
+!CHECK: {{0x[0-9a-f]+}}     29      1      1   0             0  is_stmt prologue_end
+
+subroutine show (message, array)
+  character (len=*) :: message
+  integer :: array(:)
+
+  print *, message
+  print *, array
+
+end subroutine show
+
+program prolog
+
+  interface
+     subroutine show (message, array)
+       character (len=*) :: message
+       integer :: array(:)
+     end subroutine show
+  end interface
+
+  integer :: array(10) = (/1,2,3,4,5,6,7,8,9,10/)
+
+  call show ("array", array)
+end program prolog

--- a/test/debug_info/pointer.f90
+++ b/test/debug_info/pointer.f90
@@ -1,0 +1,51 @@
+!RUN: %flang %s -g -S -emit-llvm -o - | FileCheck %s
+
+!CHECK-DAG: ![[INTEGER:[0-9]+]] = !DIBasicType(name: "integer"
+!CHECK-DAG: ![[REAL:[0-9]+]] = !DIBasicType(name: "real"
+!CHECK-DAG: ![[DOUBLE:[0-9]+]] = !DIBasicType(name: "double precision"
+!CHECK-DAG: ![[COMPLEX:[0-9]+]] = !DIBasicType(name: "complex"
+!CHECK-DAG: ![[LOGICAL:[0-9]+]] =  !DIBasicType(name: "logical"
+
+!CHECK-DAG: DILocalVariable(name: "integer_ptr"{{.*}}, type: ![[DERIVEDINTEGER:[0-9]+]]
+!CHECK-DAG: ![[DERIVEDINTEGER]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[INTEGER]]
+!CHECK-DAG: DILocalVariable(name: "real_ptr"{{.*}}, type: ![[DERIVEDREAL:[0-9]+]]
+!CHECK-DAG: ![[DERIVEDREAL]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[REAL]]
+!CHECK-DAG: DILocalVariable(name: "double_ptr"{{.*}}, type: ![[DERIVEDDOUBLE:[0-9]+]]
+!CHECK-DAG: ![[DERIVEDDOUBLE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[DOUBLE]]
+!CHECK-DAG: DILocalVariable(name: "complex_ptr"{{.*}}, type: ![[DERIVEDCOMPLEX:[0-9]+]]
+!CHECK-DAG: ![[DERIVEDCOMPLEX]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[COMPLEX]]
+!CHECK-DAG: DILocalVariable(name: "logical_ptr"{{.*}}, type: ![[DERIVEDLOGICAL:[0-9]+]]
+!CHECK-DAG: ![[DERIVEDLOGICAL]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[LOGICAL]]
+
+PROGRAM main
+
+      INTEGER, POINTER :: integer_ptr
+      REAL, POINTER :: real_ptr
+      DOUBLE PRECISION, POINTER :: double_ptr
+      COMPLEX, POINTER :: complex_ptr
+      LOGICAL, POINTER :: logical_ptr
+
+      INTEGER, TARGET :: integer_target
+      REAL, TARGET :: real_target
+      DOUBLE PRECISION, TARGET :: double_target
+      COMPLEX, TARGET :: complex_target
+      LOGICAL, TARGET :: logical_target
+
+      integer_ptr => integer_target
+      real_ptr => real_target
+      double_ptr => double_target
+      complex_ptr => complex_target
+      logical_ptr => logical_target
+
+      integer_target  = 5
+      real_target  = 5
+      double_target  = 5
+      complex_target = CMPLX(1,2)
+      logical_target  = .true.
+
+      PRINT*, integer_target
+      PRINT*, real_target
+      PRINT*, double_target
+      PRINT*, complex_target
+      PRINT*, logical_target
+END PROGRAM

--- a/test/debug_info/prolog.f90
+++ b/test/debug_info/prolog.f90
@@ -1,0 +1,38 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+! check non debug instructions should not have debug location
+!CHECK: define void @show_
+!CHECK: call void @llvm.dbg.declare
+!CHECK-SAME: , !dbg {{![0-9]+}}
+!CHECK-NOT: bitcast i64* %"array$sd" to i8*, !dbg
+!CHECK: %[[LD:[0-9]+]] = load i64, i64* %{{.*}}, align 8
+!CHECK: store i64 %[[LD]], i64* %z_b_{{.*}}, align 8
+!CHECK: br label
+!CHECK: ret void, !dbg {{![0-9]+}}
+subroutine show (message, array)
+  character (len=*) :: message
+  integer :: array(:)
+
+  print *, message
+  print *, array
+
+end subroutine show
+
+!CHECK: define void @MAIN_
+!CHECK-NOT: bitcast void (...)* @fort_init to void (i8*, ...)*, !dbg {{![0-9]+}}
+!CHECK: call void @llvm.dbg.declare
+!CHECK-SAME: , !dbg {{![0-9]+}}
+!CHECK: ret void, !dbg
+program prolog
+
+  interface
+     subroutine show (message, array)
+       character (len=*) :: message
+       integer :: array(:)
+     end subroutine show
+  end interface
+
+  integer :: array(10) = (/1,2,3,4,5,6,7,8,9,10/)
+
+  call show ("array", array)
+end program prolog

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -142,6 +142,7 @@ struct LL_DebugInfo {
   LL_MDRef cur_module_mdnode;
   LL_MDRef cur_cmnblk_mdnode;
   int cur_subprogram_lineno;
+  LL_MDRef cur_subprogram_line_mdnode;
   LL_MDRef cur_subprogram_null_loc;
   LL_MDRef cur_line_mdnode;
   PARAMINFO param_stack[PARAM_STACK_SIZE];
@@ -2316,8 +2317,10 @@ lldbg_emit_subprogram(LL_DebugInfo *db, SPTR sptr, DTYPE ret_dtype, int findex,
                                db->import_entity_list->entity_type);
     db->import_entity_list = db->import_entity_list->next;
   }
-    db->cur_subprogram_null_loc =
-        lldbg_create_location_mdnode(db, 0, 0, db->cur_subprogram_mdnode);
+  db->cur_subprogram_null_loc =
+      lldbg_create_location_mdnode(db, 0, 0, db->cur_subprogram_mdnode);
+  db->cur_subprogram_lineno = lineno;
+  db->cur_subprogram_line_mdnode = ll_get_md_null();
   db->param_idx = 0;
   memset(db->param_stack, 0, sizeof(PARAMINFO) * PARAM_STACK_SIZE);
   lldbg_emit_lexical_blocks(db, sptr, findex, targetNVVM);
@@ -2461,6 +2464,10 @@ lldbg_emit_line(LL_DebugInfo *db, int lineno)
       db->cur_line_mdnode =
           lldbg_create_location_mdnode(db, lineno, 1, db->blk_tab[idx].mdnode);
     }
+    // it is not yet column aware so comparing only line
+    if (lineno == db->cur_subprogram_lineno)
+      db->cur_subprogram_line_mdnode = db->cur_line_mdnode;
+
     last_line = lineno;
   }
 }
@@ -3322,7 +3329,8 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
 
   /* If it's an associate statement, associating another variable
    * take the type of associated variable.*/
-  if (REVMIDLNKG(sptr) && CCSYMG(sptr) && !SDSCG(REVMIDLNKG(sptr)))
+  if (REVMIDLNKG(sptr) && CCSYMG(sptr) && !SDSCG(REVMIDLNKG(sptr))
+		  && ADDRTKNG(REVMIDLNKG(sptr)))
     type_mdnode =
       lldbg_emit_type(db, DTYPEG(REVMIDLNKG(sptr)), sptr, findex, false, false, false);
   else
@@ -3785,3 +3793,6 @@ new_debug_name(const char *str1, const char *str2, const char *str3)
   return (const char *)new_name;
 }
 
+LL_MDRef lldbg_get_subprogram_line(LL_DebugInfo *db) {
+  return db->cur_subprogram_line_mdnode;
+}

--- a/tools/flang2/flang2exe/lldebug.h
+++ b/tools/flang2/flang2exe/lldebug.h
@@ -273,4 +273,6 @@ void InitializeDIFlags(const LL_IRFeatures *feature);
 
 void lldbg_reset_module(LL_DebugInfo *db);
 
+/// \brief Get the debug location mdnode of the current procedure.
+LL_MDRef lldbg_get_subprogram_line(LL_DebugInfo *db);
 #endif /* LLDEBUG_H_ */


### PR DESCRIPTION
Flang debuggability patch for:
	1. Enabling debug metadata creation for OpenMP offloaded regions. (SWDEV-237266)
	2. Enabling the right .debug_line entry to be marked as 'prologue_end' for flang
	3. Distinguishing between an associate name and a pointer so that the type of the pointer and not the pointee is recorded.

Patch contributed by: bhuvanendra.kumarn@amd.com, alokkumar.sharma@amd.com, sourabhsingh.tomar@amd.com