### PR TITLE
Fixing the error in initializing the parameters with character kind

### DIFF
--- a/tools/flang1/flang1exe/dinit.c
+++ b/tools/flang1/flang1exe/dinit.c
@@ -818,24 +818,21 @@ dinit_acl_val2(int sptr, int dtype, ACL *ict, int op)
           case AC_I_selected_real_kind:
             process_real_kind(sptr, subict, op);
             break;
+          case AC_I_selected_char_kind:
+            ast = subict->u1.ast;
+            if (A_TYPEG(ast) == A_CNST) {
+              int dty;
+              con1 = A_SPTRG(ast);
+              dty = DTY(DTYPEG(con1));
+              if (dty == TY_CHAR || dty == TY_NCHAR)
+                conval = _selected_char_kind(con1);
+              else
+                break;
+            }
+            setConval(sptr, conval, op);
+            break;
           }
-        case AC_I_selected_char_kind:
-          ast = subict->u1.ast;
-          if (A_TYPEG(ast) == A_CNST) {
-            int dty;
-            con1 = A_SPTRG(ast);
-            dty = DTY(DTYPEG(con1));
-            if (dty == TY_CHAR || dty == TY_NCHAR)
-              conval = _selected_char_kind(con1);
-            else
-              break;
-          }
-          setConval(sptr, conval, op);
-          break;
-        default:
-          error(155, 3, gbl.lineno,
-                "Invalid initialization of kind type parameter", SYMNAME(sptr));
-        }
+	}
       }
       dinit_intr_call(sptr, dtype, ict);
       break;


### PR DESCRIPTION
The change fixes the following testcase

module KIND_BIG_Singleton

  type, public :: KindBigSingleton
    integer :: &
      CHARACTER  = selected_char_kind ( 'ASCII' ), &
      SUPERSCRIPT_MINUS = int ( z'003F' ), &
      SUPERSCRIPT_1     = int ( z'003F' )
  end type

  type ( KindBigSingleton ), public, parameter :: &
    KIND_BIG = KindBigSingleton ( )

  integer, public, parameter :: &
    KBCH = KIND_BIG % CHARACTER

end module KIND_BIG_Singleton

module UNIT_Singleton

  use KIND_BIG_Singleton, &
        KB => KIND_BIG

  implicit none
  private

    character ( 5, KBCH ) :: &
      MeV_Minus_1_KBCH &
        = 'MeV' // char ( KB % SUPERSCRIPT_MINUS, KBCH ) &
                     // char ( KB % SUPERSCRIPT_1, KBCH )

end module UNIT_Singleton

program main
use KIND_BIG_Singleton

print *, KIND_BIG%CHARACTER

end program

flang is not able to compile above program and generates internal error.