### PR TITLE
Fixing the issues with structure initializer for amdgcn target

### DIFF
--- a/tools/flang2/flang2exe/llassem.cpp
+++ b/tools/flang2/flang2exe/llassem.cpp
@@ -1436,16 +1436,10 @@ process_dsrt(DSRT *dsrtp, ISZ_T size, char *cptr, bool stop_at_sect, ISZ_T addr)
     if (skip_size > 0) {
       if (ptrcnt) {
         if (!first_data && skip_size)
-// TODO Fix this more generically!
-          if (!flg.amdgcn_target)
             fprintf(ASMFIL, ", ");
         if (!i8cnt) {
-// TODO Fix this more generically!
-          if (!flg.amdgcn_target) {
-            ptr = put_next_member(ptr);
-            fprintf(ASMFIL, "zeroinitializer ");
-          }
-
+          ptr = put_next_member(ptr);
+          fprintf(ASMFIL, "zeroinitializer ");
           free(cptrCopy);
           return dsrtp;
         }


### PR DESCRIPTION
The issue is found when compiling Genasis application when compiling PackedStorage_Form.f90

flang -c -D_use_includes=1 -I/opt/openmpi-4.0.3/include -I/usr/lib/aomp_11.7-1/include -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906 -O2  -I/usr/local/silo/silo-4.10.2/include -I/usr/include/hdf5/serial    -I/tmp/genasis/Build /tmp/genasis/Modules/Basics/DataManagement/Storages/PackedStorage_Form.f90

/tmp/PackedStorage_Form-22e25f.ll:28:66: error: initializer with  struct type has wrong # elements
