### PR TITLE
[SWDEV-247457] Fix for parsing map clause with complex structure element references

### DIFF
--- a/test/offloading/amdgpu/mem_no_ptr.F90
+++ b/test/offloading/amdgpu/mem_no_ptr.F90
@@ -1,0 +1,51 @@
+!
+! Copyright (c) 2019, Advanced Micro Devices, Inc. All rights reserved.
+!
+! This is an unit test case addded for checking mapping of pointers
+! which are allocated in global structure.
+!
+! Date of Creation: 28th August 2020
+!
+subroutine init(asi)
+  integer, dimension(10, 10) :: asi
+  !$omp target teams distribute map(asi)
+  do i = 1, 10
+    do j = 1, 10
+      asi(i, j) = i + j
+    end do
+  end do
+  !$omp end target teams distribute
+end subroutine
+
+
+program foo
+  type my_type
+      integer, dimension(:, :), allocatable :: psi
+  end type my_type
+
+  integer, dimension(10, 10) :: asi
+  integer :: i, j
+
+  type(my_type) :: my_var
+
+  allocate(my_var%psi(10, 10))
+
+  do i = 1, 10
+    do j = 1, 10
+      asi(i, j) = i + j
+    end do
+  end do
+
+  !$omp target data map(my_var%psi)
+  call init(my_var%psi)
+  !$omp end target data
+
+  do i = 1, 10
+    do j = 1, 10
+      if (my_var%psi(i, j) .ne. asi(i, j)) then
+        stop 10
+      endif
+    end do
+  end do
+
+end program foo

--- a/tools/flang1/flang1exe/lowerilm.c
+++ b/tools/flang1/flang1exe/lowerilm.c
@@ -5273,10 +5273,19 @@ lower_stmt(int std, int ast, int lineno, int label)
   case A_MP_MAP:
       lower_start_stmt(lineno, label, TRUE, std);
       lop = A_LOPG(ast);
+      rop = A_ROPG(ast); // AOCC
       lower_expression(lop);
-      //todo ompaccel need to pass size and base
       flag = A_PRAGMATYPEG(STD_AST(std));
-      plower("oin", "MP_MAP", lower_base(lop), flag);
+      // AOCC Begin
+      if (rop) {
+        lower_expression(rop);
+        //todo ompaccel need to pass size and base
+        plower("oini", "MP_MAP_MEM", lower_base(lop), flag, lower_base(rop));
+      } else {
+      // AOCC End
+        //todo ompaccel need to pass size and base
+        plower("oini", "MP_MAP", lower_base(lop), flag);
+      }
       lower_end_stmt(std);
     break;
   case A_MP_BREDUCTION:

--- a/tools/flang1/flang1exe/semsmp.c
+++ b/tools/flang1/flang1exe/semsmp.c
@@ -10,7 +10,7 @@
  * Notified per clause 4(b) of the license.
  *
  * Changes to support AMDGPU OpenMP offloading.
- * Last Modified: July 2020
+ * Last Modified: Aug 2020
  *
  * Support for x86-64 OpenMP offloading
  * Last modified: Mar 2020
@@ -7948,6 +7948,11 @@ do_map()
       (void)add_stmt(ast);
       A_LOPP(ast, item->ast);
       A_PRAGMATYPEP(ast, item->t.cltype);
+      // AOCC Begin
+      if (A_TYPEG(item->ast) == A_MEM) {
+        A_ROPP(ast, A_PARENTG(item->ast));
+      }
+      // AOCC End
       // TODO ompaccel do later lower/upper bounds
     }
   }

--- a/tools/flang2/flang2exe/expsmp.cpp
+++ b/tools/flang2/flang2exe/expsmp.cpp
@@ -9,7 +9,7 @@
  * Notified per clause 4(b) of the license.
  *
  * Changes to support AMDGPU OpenMP offloading.
- * Last modified: Apr 2020
+ * Last modified: Aug 2020
  *
  * Support for x86-64 OpenMP offloading
  * Last modified: May 2020
@@ -2993,6 +2993,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
         exp_ompaccel_looptripcount(ilmp, curilm);
       break;
     case IM_MP_MAP:
+    case IM_MP_MAP_MEM: // AOCC
       // AOCC : Modification
       // Removed gbl.ompaccel_intarget from condition or else it will disable
       // replacer, leading to usage of host symbols in device

--- a/tools/flang2/flang2exe/ompaccel.cpp
+++ b/tools/flang2/flang2exe/ompaccel.cpp
@@ -1336,7 +1336,8 @@ ompaccel_tinfo_current_addupdate_mapitem(SPTR host_symbol, int map_type)
     ompaccel_msg_interr("XXX", "Current target info is not found\n");
 
   // check whether it is allocatable or not
-  if (SCG(host_symbol) == SC_BASED) {
+  if (SCG(host_symbol) == SC_BASED &&
+                                  STYPEG(host_symbol) != ST_MEMBER) { // AOCC
     /* if it is in data mode, we should keep midnum at active symbols*/
     if (current_tinfo->mode == mode_target_data_enter_region ||
         current_tinfo->mode == mode_target_data_exit_region ||
@@ -1372,7 +1373,8 @@ ompaccel_tinfo_current_add_sym(SPTR host_symbol, SPTR device_symbol,
     }
   }
   // AOCC End
-  if ((MIDNUMG(host_symbol) && SCG(host_symbol) == SC_BASED)) {
+  if ((MIDNUMG(host_symbol) && SCG(host_symbol) == SC_BASED)
+                            && STYPEG(host_symbol) != ST_MEMBER) { // AOCC
     NEED((current_tinfo->n_quiet_symbols + 1), current_tinfo->quiet_symbols,
          OMPACCEL_SYM, current_tinfo->sz_quiet_symbols,
          current_tinfo->sz_quiet_symbols * INC_EXP);
@@ -1396,7 +1398,9 @@ ompaccel_tinfo_current_add_sym(SPTR host_symbol, SPTR device_symbol,
   // AOCC Begin
   // For pointer arrays copy array descripor to device
 #ifdef OMP_OFFLOAD_AMD
-  if (SDSCG(host_symbol) && (MIDNUMG(host_symbol)) && POINTERG(host_symbol)) {
+  if (SDSCG(host_symbol) && (MIDNUMG(host_symbol) > NOSYM)
+                                      && POINTERG(host_symbol)
+                                      && STYPEG(host_symbol) != ST_MEMBER) {
     ompaccel_tinfo_current_add_sym(SDSCG(host_symbol), NOSYM,
                                    OMP_TGT_MAPTYPE_TARGET_PARAM |
                                    OMP_TGT_MAPTYPE_TO |
@@ -3050,6 +3054,7 @@ void
 exp_ompaccel_map(ILM *ilmp, int curilm, int outlinedCnt)
 {
   int label, argilm;
+  int base = 0; // AOCC
   SPTR sptr;
   if (outlinedCnt >= 2)
     return;
@@ -3062,7 +3067,16 @@ exp_ompaccel_map(ILM *ilmp, int curilm, int outlinedCnt)
     sptr = ILM_SymOPND(mapop, 2); // make 2
     label = ILM_OPND(ilmp, 2);    /* map type */
   }
+
+  // AOCC Begin
+  if (STYPEG(sptr) == ST_MEMBER && ILM_OPC(ilmp) == IM_MP_MAP_MEM) {
+    base = ILM_OPND(ilmp, 3);
+    base = ILI_OF(base);
+  }
+  // AOCC End
+
   ompaccel_tinfo_current_addupdate_mapitem(sptr, label);
+  current_tinfo->symbols[current_tinfo->n_symbols-1].ili_base = base; // AOCC
 }
 
 void

--- a/tools/flang2/utils/ilmtp/x86_64/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/x86_64/ilmtp.n
@@ -3680,6 +3680,16 @@ map with to map type
 lnk - symbol to be mapped
 stc - map type
 .fi
+\" AOCC BEGIN
+.AT spec trm
+.IL MP_MAP_MEM SMP lnk stc lnk
+map with to map type
+.nf
+lnk - symbol to be mapped
+stc - map type
+lnk - Base incase of memory pointers
+.fi
+\" AOCC END
 .AT spec trm
 .IL MP_REDUCTIONITEM SMP sym sym stc
 Begin of reduction clause.

--- a/tools/flang2/utils/upper/upperilm.in
+++ b/tools/flang2/utils/upper/upperilm.in
@@ -623,6 +623,7 @@ XOR64	ilm	ilm
 XOR8/KXOR	ilm	ilm
 MP_MAP ilm num
 #AOCC Begin
+MP_MAP_MEM ilm num ilm
 MP_DEFAULTMAP num
 MP_NUMTEAMS sym
 MP_NUMTHREADS sym


### PR DESCRIPTION
The pull request fixes the issue in parsing the complex structure references. It fixes the following testcase issue.

MODULE definitions_module

IMPLICIT NONE
  TYPE field_type
    REAL(KIND=8),    DIMENSION(:,:), ALLOCATABLE :: density0,density1
  END TYPE field_type

  TYPE tile_type
    TYPE(field_type):: field
  END TYPE tile_type

  TYPE chunk_type
    TYPE(tile_type), DIMENSION(:), ALLOCATABLE :: tiles
  END TYPE chunk_type
  TYPE(chunk_type)       :: chunk
END MODULE definitions_module
SUBROUTINE start
  use definitions_module
!$omp target data map(                   &
!$omp   chunk%tiles(1)%field%density0,   &
!$omp   chunk%tiles(1)%field%density1)

  DO tile=1,tiles_per_chunk
    CALL initialise_chunk(tile)
  ENDDO
!$omp end target data

END SUBROUTINE start
