### PR TITLE
runtime Fix for map clause with complex structure element references

### DIFF
--- a/tools/flang2/flang2exe/ompaccel.cpp
+++ b/tools/flang2/flang2exe/ompaccel.cpp
@@ -3054,7 +3054,7 @@ void
 exp_ompaccel_map(ILM *ilmp, int curilm, int outlinedCnt)
 {
   int label, argilm;
-  int base = 0; // AOCC
+  int base = 0, ili_sptr = 0; // AOCC
   SPTR sptr;
   if (outlinedCnt >= 2)
     return;
@@ -3072,11 +3072,18 @@ exp_ompaccel_map(ILM *ilmp, int curilm, int outlinedCnt)
   if (STYPEG(sptr) == ST_MEMBER && ILM_OPC(ilmp) == IM_MP_MAP_MEM) {
     base = ILM_OPND(ilmp, 3);
     base = ILI_OF(base);
+    ili_sptr = ILI_OF(argilm);
   }
   // AOCC End
 
   ompaccel_tinfo_current_addupdate_mapitem(sptr, label);
-  current_tinfo->symbols[current_tinfo->n_symbols-1].ili_base = base; // AOCC
+
+  // AOCC Begin
+  assert(current_tinfo->n_symbols, "Expecting atleast one symbol", 0,
+                                                              ERR_Fatal);
+  current_tinfo->symbols[current_tinfo->n_symbols-1].ili_base = base;
+  current_tinfo->symbols[current_tinfo->n_symbols-1].ili_sptr = ili_sptr;
+  // AOCC End
 }
 
 void

--- a/tools/flang2/flang2exe/ompaccel.h
+++ b/tools/flang2/flang2exe/ompaccel.h
@@ -53,6 +53,9 @@ typedef struct {
   int ili_base;         /* symbol base */
   int ili_lowerbound;   /* lower bound */
   int ili_length;       /* length */
+  int ili_sptr;         /* ili for sptr, // AOCC
+                           ili_base represents base of struct,
+                           this represets offsetted pointer */
 } OMPACCEL_SYM;
 
 /* Target Info is the main struct which keeps all the information about target

--- a/tools/flang2/flang2exe/tgtutil.cpp
+++ b/tools/flang2/flang2exe/tgtutil.cpp
@@ -336,9 +336,9 @@ _tgt_target_fill_size(SPTR sptr, int map_type, int base_ili)
             ilix = ad3ili(IL_AADD, base_ili, ad_aconi(ADDRESSG(sdsc)), 0);
             ilix = ad3ili(IL_AADD, ilix, ad_aconi(48), 0);
             ilix = ad3ili(IL_LD, ilix, nme, MSZ_WORD);
-            return ilix;
+          } else {
+            ilix = ad3ili(IL_LD, ad_acon(sdsc, 48), nme, MSZ_WORD);
           }
-          ilix = ad3ili(IL_LD, ad_acon(sdsc, 48), nme, MSZ_WORD);
           ilix = ad2ili(IL_KMUL, ilix, ad_kconi(size_of((DTYPE)(dtype + 1))));
           return ilix;
         }
@@ -525,9 +525,8 @@ tgt_target_fill_params(SPTR arg_base_sptr, SPTR arg_size_sptr, SPTR args_sptr,
         load_dtype = param_dtype;
       // AOCC Begin
       } else if (AD_SDSC(ad) && AD_ZBASE(ad) &&
-                                targetinfo->symbols[i].ili_base) {
-        iliy = targetinfo->symbols[i].ili_base;
-        iliy = ad3ili(IL_AADD, iliy, ad_aconi(ADDRESSG(param_sptr)), 0);
+                                targetinfo->symbols[i].ili_sptr) {
+        iliy = targetinfo->symbols[i].ili_sptr;
         load_dtype = DT_ADDR;
       // AOCC End
       } else {


### PR DESCRIPTION
The pull request fixes the runtime issue with the testcase associated with the previous submit.

MODULE definitions_module

  IMPLICIT NONE
  TYPE field_type
    REAL(KIND=8),    DIMENSION(:,:), ALLOCATABLE :: density0,density1
  END TYPE field_type

  TYPE tile_type
    TYPE(field_type):: field
  END TYPE tile_type

  TYPE chunk_type
    TYPE(tile_type), DIMENSION(:), ALLOCATABLE :: tiles
  END TYPE chunk_type
  TYPE(chunk_type)       :: chunk
END MODULE definitions_module
SUBROUTINE start
  use definitions_module
  ALLOCATE(chunk%tiles (1))
  ALLOCATE(chunk%tiles(1)%field%density0  (-1:962,-1:962))
  ALLOCATE(chunk%tiles(1)%field%density1  (-1:962,-1:962))

print '(Z)', loc(chunk%tiles(1))
print '(Z)', loc(chunk%tiles(1)%field)
print '(Z)', loc(chunk%tiles(1)%field%density0)
print '(Z)', loc(chunk%tiles(1)%field%density1)

call flush(6)
!$omp target data map(                   &
!$omp   chunk%tiles(1)%field%density0,   &
!$omp   chunk%tiles(1)%field%density1)

  DO tile=1,2
    chunk%tiles(1)%field%density0(tile,-1) =0
    chunk%tiles(1)%field%density1(tile,-1) =0
  ENDDO
!$omp end target data

END SUBROUTINE start
program foobar
   call start
end program
