### PR TITLE
Flang debuggability patch 

### DIFF
--- a/test/debug_info/associated.f90
+++ b/test/debug_info/associated.f90
@@ -3,8 +3,8 @@
 !CHECK !DILocalVariable(name: "ptr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
 !CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
 !CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
-!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_constu, 4, DW_OP_mul))
-!CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_constu, 4, DW_OP_mul))
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 168, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
 program main
   integer, target :: arr(10, 10)
   integer, pointer :: ptr(:, :)

--- a/test/debug_info/assumed_shape_non_contiguous.f90
+++ b/test/debug_info/assumed_shape_non_contiguous.f90
@@ -1,0 +1,33 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: call void @llvm.dbg.value(metadata i64* %array, metadata [[ARRAYDL:![0-9]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.declare(metadata i64* %"array$sd", metadata [[ARRAY:![0-9]+]], metadata !DIExpression())
+!CHECK-LABEL: distinct !DICompileUnit(language: DW_LANG_Fortran90,
+!CHECK: [[ARRAY]] = !DILocalVariable(name: "array", arg: 2, scope: {{![0-9]+}}, file: {{![0-9]+}}, line: {{[0-9]+}}, type: [[TYPE:![0-9]+]])
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: [[ARRAYDL]])
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]], [[ELEM2:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: 1, upperBound: {{![0-9]+}}, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_constu, 4, DW_OP_mul))
+!CHECK: [[ELEM2]] = !DISubrange(lowerBound: 1, upperBound: {{![0-9]+}}, stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 160, DW_OP_deref, DW_OP_constu, 4, DW_OP_mul))
+
+subroutine show (message, array)
+  character (len=*) :: message
+  integer :: array(:,:)
+
+  print *, message
+  print *, array
+
+end subroutine show
+
+program test
+
+  interface
+     subroutine show (message, array)
+       character (len=*) :: message
+       integer :: array(:,:)
+     end subroutine show
+  end interface
+
+  integer :: parray(4,4) = reshape((/1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16/),(/4,4/))
+
+  call show ("parray", parray(1:2,1:2))
+end program test

--- a/test/debug_info/common.f90
+++ b/test/debug_info/common.f90
@@ -1,0 +1,15 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: distinct !DIGlobalVariable(name: "cvar1", linkageName: "cname_", scope: [[CBLOCK:![0-9]+]]
+!CHECK: [[CBLOCK]] = distinct !DICommonBlock(scope: !3, declaration: null, name: "cname")
+!CHECK-NOT: distinct !DIGlobalVariable(name: "cname"
+!CHECK: distinct !DIGlobalVariable(name: "cvar2", linkageName: "cname_", scope: [[CBLOCK]]
+
+program main
+  integer :: cvar1, cvar2
+  common /cname/ cvar1, cvar2
+  cvar1 = 1
+  cvar2 = 2
+  print *, cvar1
+  print *, cvar2
+end program main

--- a/test/debug_info/conststring.f90
+++ b/test/debug_info/conststring.f90
@@ -1,0 +1,21 @@
+!! check if conststrings are stored correctly for special characters
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!! \0 = 0 , " = 34 = 0x22
+!CHECK: call void @llvm.dbg.value(metadata [10 x i8] c"a\00d\22g     ", metadata [[CONSTR1:![0-9a-f]+]], metadata !DIExpression())
+!CHECK: call void @llvm.dbg.value(metadata [10 x i8] c"h i~j     ", metadata [[CONSTR2:![0-9a-f]+]], metadata !DIExpression())
+!! \n = 10 \r = 13
+!CHECK: call void @llvm.dbg.value(metadata [10 x i8] c"k\0Al\0Dm     ", metadata [[CONSTR3:![0-9a-f]+]], metadata !DIExpression())
+!CHECK: [[CONSTR1]] = !DILocalVariable(name: "constr1",
+!CHECK: [[CONSTR2]] = !DILocalVariable(name: "constr2",
+!CHECK: [[CONSTR3]] = !DILocalVariable(name: "constr3",
+
+program main
+  character(10),parameter :: constr1 = "a"//achar(0)//"d"//achar(34)//"g"
+  character(10),parameter :: constr2 = "h i~j"
+  character(10),parameter :: constr3 = "k"//achar(10)//"l"//achar(13)//"m"
+
+  print *,constr1
+  print *,constr2
+  print *,constr3
+end

--- a/test/debug_info/dertyp_sclr_ptr.f90
+++ b/test/debug_info/dertyp_sclr_ptr.f90
@@ -1,0 +1,28 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+
+!CHECK:  call void @llvm.dbg.declare(metadata %struct.dtype** %"dptr$p_{{[0-9]+}}", metadata [[DVAR:![0-9]+]], metadata !DIExpression())
+!CHECK: [[DTYPE:![0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "dtype", file: !3, size: 32, align: 32, elements: [[ELEM:![0-9]+]])
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DIDerivedType(tag: DW_TAG_member, name: "avar"
+!CHECK: [[DVAR]] = !DILocalVariable(name: "dptr", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: [[TYPE:![0-9]+]])
+!CHECK: [[TYPE]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: {{![0-9]+}}, size: 64, align: 64
+
+program main
+  implicit none
+
+  type :: dtype
+    integer :: avar
+  end type dtype
+
+  type (dtype), target :: tvar
+  type(dtype), pointer :: dptr
+
+  nullify (dptr)
+
+  tvar%avar = 3
+
+  dptr => tvar
+  nullify (dptr)
+
+end program main

--- a/test/debug_info/dertyp_striding.f90
+++ b/test/debug_info/dertyp_striding.f90
@@ -1,0 +1,20 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK !DILocalVariable(name: "pvar", scope: {{![0-9]+}}, file: {{![0-9]+}}, type: {{![0-9]+}})
+!CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 64, align: 64, elements: [[ELEM:![0-9]+]], dataLocation: {{![0-9]+}})
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 80, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 120, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 112, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+program main
+    type dtype
+        integer(kind=8) :: x
+        integer(kind=8) :: y
+        integer(kind=8) :: z
+    end type
+    type(dtype), dimension(10), target :: tvar
+    integer(kind=8), dimension(:), pointer :: pvar => null()
+    tvar(:)%x = 1
+    tvar(:)%y = 2
+    tvar(:)%z = 3
+    pvar => tvar(1:9)%y
+    print *, pvar
+end program

--- a/test/debug_info/func_return_type.f90
+++ b/test/debug_info/func_return_type.f90
@@ -1,0 +1,16 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!Verify the function return type is not of pointer type
+!CHECK: !DIBasicType(name: "real"
+!CHECK-NOT: !DIDerivedType(tag: DW_TAG_pointer_type
+
+function square(x)
+  real, intent(in) :: x
+  real :: square
+  square = x * x
+end function
+program main
+  real :: a, b, square
+  a = 2.0
+  b = square(a)
+end program main

--- a/test/debug_info/nametable.f90
+++ b/test/debug_info/nametable.f90
@@ -1,0 +1,16 @@
+!RUN: %flang %s -gdwarf-5 -S -emit-llvm -o - | FileCheck %s --check-prefix=NONAMESECTION
+!RUN: %flang %s -g -S -emit-llvm -o - | FileCheck %s --check-prefix=NOPUBNAMESECTION
+
+!Ensure that "nameTableKind: None" field is present in DICompileUnit.
+!NONAMESECTION: !DICompileUnit({{.*}}, nameTableKind: None
+!NOPUBNAMESECTION: !DICompileUnit({{.*}}, nameTableKind: None
+
+!RUN: %flang %s -gdwarf-5 -gpubnames -S -emit-llvm -o - | FileCheck %s --check-prefix=NAMESECTION
+!RUN: %flang %s -g -gpubnames -S -emit-llvm -o - | FileCheck %s --check-prefix=PUBNAMESECTION
+
+!Ensure that "nameTableKind: None" field is not present in DICompileUnit.
+!NAMESECTION-NOT: !DICompileUnit({{.*}}, nameTableKind: None
+!PUBNAMESECTION-NOT: !DICompileUnit({{.*}}, nameTableKind: None
+PROGRAM main
+END PROGRAM main
+

--- a/test/debug_info/outervar.f90
+++ b/test/debug_info/outervar.f90
@@ -1,0 +1,14 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+!CHECK: distinct !DIGlobalVariable(name: "prog_i"
+!CHECK-NOT: distinct !DIGlobalVariable(name: "prog_i"
+
+program main
+  integer :: prog_i
+  prog_i = 99
+  call sub()
+contains
+  subroutine sub()
+    print *,prog_i
+  end subroutine sub
+end program main

--- a/test/debug_info/ptr_arr_member.f90
+++ b/test/debug_info/ptr_arr_member.f90
@@ -1,0 +1,21 @@
+!RUN: %flang -g -S -emit-llvm %s -o - | FileCheck %s
+
+
+!CHECK: !DIDerivedType(tag: DW_TAG_member, name: "arrptr", scope: {{![0-9]+}}, file: {{![0-9]+}}, baseType: [[TYPE:![0-9]+]]
+!CHECK: [[TYPE]] = !DICompositeType(tag: DW_TAG_array_type, baseType: {{![0-9]+}}, size: 32, align: 32, elements: [[ELEM:![0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref))
+!CHECK: [[ELEM]] = !{[[ELEM1:![0-9]+]]}
+!CHECK: [[ELEM1]] = !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 96, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 136, DW_OP_deref), stride: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 128, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_mul))
+
+program main
+
+  type dtype
+     integer, dimension(:), pointer :: arrptr
+  end type dtype
+  type(dtype) :: dvar
+
+  allocate (dvar%arrptr (5))
+
+  dvar%arrptr (1)= 9
+  print *, dvar%arrptr
+
+end program main

--- a/tools/flang1/flang1exe/main.c
+++ b/tools/flang1/flang1exe/main.c
@@ -1007,7 +1007,9 @@ init(int argc, char *argv[])
 
   if (flg.es && !flg.p)
     flg.x[123] |= 0x100;
-
+  if (flg.omptarget && flg.debug)
+    if (!XBIT(123, 0x10000000))
+      flg.x[123] |= 0x400;
   empty_cl:
   if (sourcefile == NULL) {
     if (flg.ipa & 0x0a) {

--- a/tools/flang2/docs/xflag.n
+++ b/tools/flang2/docs/xflag.n
@@ -3248,7 +3248,7 @@ Generating eh_frame.
 .XB 0x20000000:
 Generating eh_frame with .cfi directives: requires 120,0x10000000 to be on
 .XB 0x40000000
-AVAILABLE
+Generate .debug_names/.debug_pubnames section.
 .XB 0x80000000:
 no license check in executable.
 
@@ -3447,7 +3447,7 @@ Use the legacy Fortran preprocessor (fpp), and not the ANSI-C99 preprocessor.
 .XB 0x8000000
 Preprocessor puts out dependence lines to gbl.cppfil instead of file.d or stdout
 .XB 0x10000000
-Unused.
+With -fopenmp and -g options, XBIT(123,0x400) is set by default. This option overrides it.
 .XB 0x20000000
 preprocessor generates makefile information to stdout; driver option -MT
 .XB 0x40000000

--- a/tools/flang2/flang2exe/cgmain.h
+++ b/tools/flang2/flang2exe/cgmain.h
@@ -286,6 +286,15 @@ bool ftn_array_need_debug_info(SPTR sptr);
 void insert_llvm_dbg_declare(LL_MDRef mdnode, SPTR sptr, LL_Type *llTy,
                              OPERAND *exprMDOp, OperandFlag_t opflag);
 
+/**
+   \brief Insert <tt>@llvm.dbg.value</tt> call for debug
+   \param OPERAND operand
+   \param sptr    symbol
+   \param llTy    preferred type of \p sptr or \c NULL
+ */
+void insert_llvm_dbg_value(OPERAND *load, LL_MDRef mdnode, SPTR sptr,
+                           LL_Type *type);
+
 // AOCC Begin
 /**
   \brief Function to calculate alloca address space.

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -931,7 +931,8 @@ enum FieldType {
   DWVirtualityField,
   DWEncodingField,
   DWEmissionField,
-  SignedOrMDField
+  SignedOrMDField,
+  DebugNameTableKindField
 };
 
 enum FieldFlags {
@@ -1023,7 +1024,7 @@ static const MDTemplate Tmpl_DICompileUnit[] = {
 
 /* "subprograms" removed from DICompileUnit in LLVM 3.9 */
 static const MDTemplate Tmpl_DICompileUnit_ver39[] = {
-  { "DICompileUnit", TF, 13 },
+  { "DICompileUnit", TF, 14 },
   { "tag",                      DWTagField, FlgHidden },
   { "file",                     NodeField },
   { "language",                 DWLangField },
@@ -1036,7 +1037,8 @@ static const MDTemplate Tmpl_DICompileUnit_ver39[] = {
   { "globals",                  NodeField },
   { "emissionKind",             DWEmissionField },
   { "imports",                  NodeField },
-  { "splitDebugFilename",       StringField }
+  { "splitDebugFilename",       StringField },
+  { "nameTableKind",            DebugNameTableKindField }
 };
 
 static const MDTemplate Tmpl_DICompileUnit_pre34[] = {
@@ -1620,6 +1622,24 @@ dwarf_emission_name(int value)
 }
 
 /**
+   \brief generate DWARF table kind
+ */
+static const char *
+dwarf_table_name(int value)
+{
+  switch (value) {
+  case 0:
+    return "Default";
+  case 1:
+    return "GNU";
+  case 2:
+    return "None";
+  default:
+    return "None";
+  }
+}
+
+/**
    \brief Write out an an LL_MDRef as a field in a specialised MDNode class
    \param out        file to write to
    \param module       module containing the metadata
@@ -1755,6 +1775,10 @@ write_mdfield(FILE *out, LL_Module *module, int needs_comma, LL_MDRef mdref,
 
     case DWEmissionField:
       fprintf(out, "%s%s: %s", prefix, tmpl->name, dwarf_emission_name(value));
+      break;
+
+    case DebugNameTableKindField:
+      fprintf(out, "%s%s: %s", prefix, tmpl->name, dwarf_table_name(value));
       break;
 
     default:

--- a/tools/flang2/flang2exe/lldebug.cpp
+++ b/tools/flang2/flang2exe/lldebug.cpp
@@ -182,11 +182,20 @@ static LL_MDRef lldbg_create_file_mdnode(LL_DebugInfo *db, char *filename,
 static LL_MDRef lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr,
                                 int findex, bool is_reference,
                                 bool skip_first_dim,
-                                bool skipDataDependentTypes);
+                                bool skipDataDependentTypes,
+                                SPTR data_sptr = SPTR_NULL);
 static LL_MDRef lldbg_fwd_local_variable(LL_DebugInfo *db, int sptr, int findex,
                                          int emit_dummy_as_local);
 static void lldbg_emit_imported_entity(LL_DebugInfo *db, SPTR entity_sptr,
                                        SPTR func_sptr, IMPORT_TYPE entity_type);
+static LL_MDRef lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb,
+                                             LL_MDRef ub, LL_MDRef st);
+static LL_MDRef lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex,
+                                               SPTR sptr, int rank);
+static void lldbg_get_bounds_for_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
+                                      int rank, LL_MDRef *lbnd_expr_mdnode,
+                                      LL_MDRef *ubnd_expr_mdnode,
+                                      LL_MDRef *stride_expr_mdnode);
 /* ---------------------------------------------------------------------- */
 
 void
@@ -334,6 +343,8 @@ lldbg_create_compile_unit_mdnode(LL_DebugInfo *db, int lang_tag, char *filename,
       llmd_add_i32(mdb, 1); /* emissionMode: FullDebug */
     llmd_add_md(mdb, *imported_entity_list);
     llmd_add_string(mdb, "");
+    if (!XBIT(120, 0x40000000))
+      llmd_add_i32(mdb, 2); /* nameTableKind: None */
   }
 
   llmd_set_distinct(mdb);
@@ -917,7 +928,7 @@ lldbg_create_aggregate_members_type(LL_DebugInfo *db, SPTR first, int findex,
           contains_allocatable = true;
           db->need_dup_composite_type |= true;
         }
-      } else {
+      } else if (!SDSCG(element)) {
         element = SYMLKG(element);
         assert(element > NOSYM, 
                "lldbg_create_aggregate_members_type: element not exists",
@@ -1255,9 +1266,11 @@ lldbg_create_ftn_subrange_via_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
 }
 
 /* Create subrange mdnode based on array descriptor */
-static LL_MDRef lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex,
-                                               SPTR sptr, int rank) {
-  LL_MDRef lbnd_expr_mdnode, ubnd_expr_mdnode, stride_expr_mdnode;
+static void lldbg_get_bounds_for_sdsc(LL_DebugInfo *db, int findex, SPTR sptr,
+                                      int rank, LL_MDRef *lbnd_expr_mdnode,
+                                      LL_MDRef *ubnd_expr_mdnode,
+                                      LL_MDRef *stride_expr_mdnode)
+{
 
   /*
    * Please consider below derived type, which has allocatable array as member.
@@ -1280,6 +1293,7 @@ static LL_MDRef lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex,
           ? ADDRESSG(SDSCG(sptr)) - ADDRESSG(sptr)
           : 0;
 
+  const int target_size_offset = 8 * (DESC_HDR_BYTE_LEN - DESC_HDR_TAG);
   const int F90_DescDim_size = 8 * DESC_DIM_LEN;    /* sizeof(F90_DescDim)*/
   const int F90_Desc_dim_offset = 8 * DESC_HDR_LEN; /* offsetof(F90_Desc, dim)*/
   const int ubound_offset_wrt_lbound =
@@ -1298,6 +1312,7 @@ static LL_MDRef lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex,
   const unsigned v2 = lldbg_encode_expression_arg(LL_DW_OP_int, upper_offset);
   const unsigned v3 = lldbg_encode_expression_arg(LL_DW_OP_int, stride_offset);
   const unsigned v4 = lldbg_encode_expression_arg(LL_DW_OP_int, size);
+  const unsigned v5 = lldbg_encode_expression_arg(LL_DW_OP_int, target_size_offset);
 
   const unsigned add = lldbg_encode_expression_arg(LL_DW_OP_plus_uconst, 0);
   const unsigned mul = lldbg_encode_expression_arg(LL_DW_OP_mul, 0);
@@ -1306,23 +1321,34 @@ static LL_MDRef lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex,
   const unsigned pushobj =
       lldbg_encode_expression_arg(LL_DW_OP_push_object_address, 0);
 
-  lbnd_expr_mdnode =
+  if (lbnd_expr_mdnode)
+    *lbnd_expr_mdnode =
       lldbg_emit_expression_mdnode(db, 4, pushobj, add, v1, deref);
-  ubnd_expr_mdnode =
+  if (ubnd_expr_mdnode)
+    *ubnd_expr_mdnode =
       lldbg_emit_expression_mdnode(db, 4, pushobj, add, v2, deref);
-  if (size > 0)
-    stride_expr_mdnode = lldbg_emit_expression_mdnode(db, 7, pushobj, add, v3,
-                                                    deref, constu, v4, mul);
-  else
-    stride_expr_mdnode = ll_get_md_null();
+  if (stride_expr_mdnode) {
+    if (size > 0) {
+      if (POINTERG(sptr) && !ALLOCATTRG(sptr))
+        *stride_expr_mdnode = lldbg_emit_expression_mdnode(db, 9, pushobj, add, v3,
+                                                       deref, pushobj, add, v5, deref, mul);
+      else
+        *stride_expr_mdnode = lldbg_emit_expression_mdnode(db, 7, pushobj, add, v3,
+                                                       deref, constu, v4, mul);
+    } else
+      *stride_expr_mdnode = ll_get_md_null();
+  }
+}
 
-  LLMD_Builder mdb = llmd_init(db->module);
-  llmd_set_class(mdb, LL_DISubRange);
-  llmd_add_i32(mdb, make_dwtag(db, DW_TAG_subrange_type));
-  llmd_add_md(mdb, lbnd_expr_mdnode);
-  llmd_add_md(mdb, ubnd_expr_mdnode);
-  llmd_add_md(mdb, stride_expr_mdnode);
-  return llmd_finish(mdb);
+static LL_MDRef lldbg_create_subrange_via_sdsc(LL_DebugInfo *db, int findex,
+                                               SPTR sptr, int rank)
+{
+  LL_MDRef lbnd_expr_mdnode, ubnd_expr_mdnode, stride_expr_mdnode;
+  lldbg_get_bounds_for_sdsc(db, findex, sptr, rank, &lbnd_expr_mdnode,
+                            &ubnd_expr_mdnode, &stride_expr_mdnode);
+
+  return lldbg_create_subrange_mdnode(db, lbnd_expr_mdnode, ubnd_expr_mdnode,
+                                      stride_expr_mdnode);
 }
 
 static LL_MDRef lldbg_create_subrange_mdnode_pre11(LL_DebugInfo *db, ISZ_T lb,
@@ -1355,16 +1381,21 @@ static LL_MDRef lldbg_create_subrange_mdnode_pre11(LL_DebugInfo *db, ISZ_T lb,
 }
 
 static LL_MDRef lldbg_create_subrange_mdnode(LL_DebugInfo *db, LL_MDRef lb,
-                                             LL_MDRef ub) {
-  DBLINT64 count, low, high;
-  DBLINT64 one;
+                                             LL_MDRef ub, LL_MDRef st)
+{
   LLMD_Builder mdb = llmd_init(db->module);
 
   llmd_set_class(mdb, LL_DISubRange);
   llmd_add_i32(mdb, make_dwtag(db, DW_TAG_subrange_type));
   llmd_add_md(mdb, lb);
-  llmd_add_md(mdb, ub);
-  llmd_add_null(mdb);
+  if (ub != ll_get_md_null())
+    llmd_add_md(mdb, ub);
+  else
+    llmd_add_null(mdb);
+  if (st != ll_get_md_null())
+    llmd_add_md(mdb, st);
+  else
+    llmd_add_null(mdb);
 
   return llmd_finish(mdb);
 }
@@ -1759,8 +1790,12 @@ lldbg_emit_parameter_list(LL_DebugInfo *db, DTYPE dtype, DTYPE ret_dtype,
           lldbg_emit_modified_type(db, ret_dtype, SPTR_NULL, findex);
     else
 #endif
-      retval_mdnode =
-          lldbg_emit_type(db, ret_dtype, SPTR_NULL, findex, true, false, true);
+      if (DT_ISBASIC(ret_dtype))
+        retval_mdnode =
+         lldbg_emit_type(db, ret_dtype, SPTR_NULL, findex, false, false, true);
+      else
+        retval_mdnode =
+         lldbg_emit_type(db, ret_dtype, SPTR_NULL, findex, true, false, true);
   } else {
     if (ll_feature_debug_info_pre34(&db->module->ir))
       retval_mdnode = ll_get_md_null();
@@ -2739,10 +2774,10 @@ INLINE static void init_subrange_bound(LL_DebugInfo *db, LL_MDRef *bound_sptr,
   *bound_sptr = ll_get_md_i64(db->module, defVal);
 }
 
-static LL_MDRef
-lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
-                bool is_reference, bool skip_first_dim,
-                bool skipDataDependentTypes)
+static LL_MDRef lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr,
+                                int findex, bool is_reference,
+                                bool skip_first_dim,
+                                bool skipDataDependentTypes, SPTR data_sptr)
 {
   LL_MDRef cu_mdnode, file_mdnode, type_mdnode;
   LL_MDRef subscripts_mdnode, subscript_mdnode;
@@ -2900,6 +2935,61 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         ad = AD_DPTR(dtype);
         numdim = AD_NUMDIM(ad);
         if (is_legal_numdim(numdim)) { /* AOCC */
+          // Generate dataLocation field DW_TAG_array_type for assumed shape
+          // arrays, pointers and allocatables.
+          if (ll_feature_debug_info_ver11(&db->module->ir)) {
+            if ((SCG(sptr) == SC_DUMMY) && data_sptr &&
+                db->cur_subprogram_mdnode) {
+              // Assumed shape array
+              LL_Type *dataloctype = LLTYPE(data_sptr);
+              /* make_lltype_from_sptr() should have added a pointer to
+               * the type of this local variable. Remove it */
+              if (!dataloctype)
+                dataloctype = make_lltype_from_sptr(data_sptr);
+              if (dataloctype->data_type == LL_PTR)
+                dataloctype = dataloctype->sub_types[0];
+              dataloc = lldbg_emit_local_variable(db, data_sptr, findex, true);
+
+              OPERAND *ld = make_operand();
+              ld->ot_type = OT_MDNODE;
+              ld->val.sptr = data_sptr;
+
+              /* lets generate llvm.dbg.value intrinsic for it.*/
+              insert_llvm_dbg_value(ld, dataloc, data_sptr, dataloctype);
+            } else if (ALLOCATTRG(sptr) || POINTERG(sptr)) {
+              // Variables with allocatable/pointer attribute.
+              if (SCG(SDSCG(sptr)) == SC_CMBLK ||
+                  STYPEG(SDSCG(sptr)) == ST_MEMBER) {
+                const unsigned deref =
+                    lldbg_encode_expression_arg(LL_DW_OP_deref, 0);
+                const unsigned pushobj = lldbg_encode_expression_arg(
+                    LL_DW_OP_push_object_address, 0);
+                dataloc = lldbg_emit_expression_mdnode(db, 2, pushobj, deref);
+              } else {
+                SPTR datasptr = MIDNUMG(sptr);
+                if (datasptr == NOSYM)
+                  datasptr = SYMLKG(sptr);
+                if (SCG(datasptr) == SC_DUMMY) {
+                  // TODO: we want to generate local variable carrying
+                  // datalocation, but enclosing scope is not yet ready.
+                  // we shall solve it separately.
+                } else {
+                  LL_Type *dataloctype = LLTYPE(datasptr);
+                  /* make_lltype_from_sptr() should have added a pointer to
+                   * the type of this local variable. Remove it */
+                  if (!dataloctype)
+                    dataloctype = make_lltype_from_sptr(datasptr);
+                  if (dataloctype->data_type == LL_PTR)
+                    dataloctype = dataloctype->sub_types[0];
+                  dataloc =
+                      lldbg_emit_local_variable(db, datasptr, findex, true);
+                  insert_llvm_dbg_declare(dataloc, datasptr, dataloctype, NULL,
+                                          OPF_NONE);
+                }
+              }
+            }
+          }
+
           for (i = 0; i < numdim; ++i) {
             SPTR lower_bnd = AD_LWBD(ad, i);
             SPTR upper_bnd = AD_UPBD(ad, i);
@@ -2924,43 +3014,29 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
             } else if (ll_feature_debug_info_ver11(&db->module->ir)) {
               LL_MDRef lbv = ll_get_md_null();
               LL_MDRef ubv = ll_get_md_null();
+              LL_MDRef st = ll_get_md_null();
               if (ALLOCATTRG(sptr) || POINTERG(sptr)) {
-                if (SCG(SDSCG(sptr)) == SC_CMBLK ||
-                    STYPEG(SDSCG(sptr)) == ST_MEMBER) {
-                  const unsigned deref =
-                      lldbg_encode_expression_arg(LL_DW_OP_deref, 0);
-                  const unsigned pushobj = lldbg_encode_expression_arg(
-                      LL_DW_OP_push_object_address, 0);
-                  dataloc = lldbg_emit_expression_mdnode(db, 2, pushobj, deref);
-                } else {
-                  SPTR datasptr = MIDNUMG(sptr);
-                  if (datasptr == NOSYM)
-                    datasptr = SYMLKG(sptr);
-                  if (SCG(datasptr) == SC_DUMMY) {
-                    // TODO: we want to generate local variable carrying
-                    // datalocation, but enclosing scope is not yet ready.
-                    // we shall solve it separately.
-                  } else {
-                    LL_Type *dataloctype = LLTYPE(datasptr);
-                    /* make_lltype_from_sptr() should have added a pointer to
-                     * the type of this local variable. Remove it */
-                    if (!dataloctype)
-                      dataloctype = make_lltype_from_sptr(datasptr);
-                    if (dataloctype->data_type == LL_PTR)
-                      dataloctype = dataloctype->sub_types[0];
-                    dataloc =
-                        lldbg_emit_local_variable(db, datasptr, findex, true);
-                    insert_llvm_dbg_declare(dataloc, datasptr, dataloctype,
-                                            NULL, OPF_NONE);
-                  }
-                }
                 /* Create subrange mdnode based on array descriptor */
                 subscript_mdnode =
                     lldbg_create_subrange_via_sdsc(db, findex, sptr, i);
-              } else { // explicit shape, assumed shape arrays
+              } else if ((SCG(sptr) == SC_DUMMY) && data_sptr &&
+                         db->cur_subprogram_mdnode) {
+                // assumed shape array
+                LL_MDRef s_bnd;
                 init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
                 init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
-                subscript_mdnode = lldbg_create_subrange_mdnode(db, lbv, ubv);
+                lldbg_get_bounds_for_sdsc(db, findex, data_sptr, i, NULL,
+                                          NULL, &s_bnd);
+
+                subscript_mdnode =
+                    lldbg_create_subrange_mdnode(db, lbv, ubv, s_bnd);
+              } else {
+                // explicit shape array
+                init_subrange_bound(db, &lbv, lower_bnd, 1, findex);
+                init_subrange_bound(db, &ubv, upper_bnd, 0, findex);
+
+                subscript_mdnode =
+                    lldbg_create_subrange_mdnode(db, lbv, ubv, st);
               }
               llmd_add_md(mdb, subscript_mdnode);
             } else {
@@ -3034,7 +3110,8 @@ lldbg_emit_type(LL_DebugInfo *db, DTYPE dtype, SPTR sptr, int findex,
         ub = DTyVecLength(dtype) - 1;
         if (ll_feature_debug_info_ver11(&db->module->ir))
           subscript_mdnode = lldbg_create_subrange_mdnode(
-              db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub));
+              db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub),
+              ll_get_md_null());
         else
           subscript_mdnode =
               lldbg_create_subrange_mdnode_pre11(db, lb, DTyVecLength(dtype));
@@ -3107,6 +3184,10 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
   bool savedScopeIsGlobal;
   hash_data_t val;
 
+  // Dont emit if it is uplevel variable
+  if (sptr && UPLEVELG(sptr))
+    return;
+
   assert(db, "Debug info not enabled", 0, ERR_Fatal);
   if ((!sptr) || (!DTYPEG(sptr)))
     return;
@@ -3177,7 +3258,8 @@ lldbg_emit_global_variable(LL_DebugInfo *db, SPTR sptr, ISZ_T off, int findex,
         llObjtodbgAddUnique(*listp, db->gbl_obj_exp_mdnode);
     }
     ll_add_global_debug(db->module, sptr, mdref);
-    if (gbl.rutype == RU_BDATA && sc == SC_CMBLK) {
+    // `RU_SUBR` is set for modules imported from different CompileUnits.
+    if ((gbl.rutype == RU_SUBR || gbl.rutype == RU_BDATA) && sc == SC_CMBLK) {
       const char *modvar_name;
       if (CCSYMG(MIDNUMG(sptr))) {
         modvar_name = new_debug_name(SYMNAME(ENCLFUNCG(sptr)),
@@ -3333,9 +3415,12 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
 		  && ADDRTKNG(REVMIDLNKG(sptr)))
     type_mdnode =
       lldbg_emit_type(db, DTYPEG(REVMIDLNKG(sptr)), sptr, findex, false, false, false);
+  else if (ASSUMSHPG(sptr) && SDSCG(sptr))
+    type_mdnode =
+        lldbg_emit_type(db, __POINT_T, sptr, findex, false, false, false);
   else
-  type_mdnode =
-      lldbg_emit_type(db, DTYPEG(sptr), sptr, findex, false, false, false);
+    type_mdnode =
+        lldbg_emit_type(db, DTYPEG(sptr), sptr, findex, false, false, false);
 #ifdef THISG
   if (ENCLFUNCG(sptr) && THISG(ENCLFUNCG(sptr)) == sptr) {
     symname = "this";
@@ -3353,6 +3438,12 @@ lldbg_emit_local_variable(LL_DebugInfo *db, SPTR sptr, int findex,
            sptr, ERR_Fatal);
   } else {
     int flags = set_dilocalvariable_flags(sptr);
+
+    // This is base address of Assumed shape array, need to be used as
+    // dataLocation field of DW_TAG_array_type. Make it artificial.
+    if (ASSUMSHPG(sptr) && SDSCG(sptr))
+      flags = DIFLAG_ARTIFICIAL;
+
     BLKINFO *blk_info = get_lexical_block_info(db, sptr, true);
     LL_MDRef fwd;
     hash_data_t val;
@@ -3429,8 +3520,13 @@ lldbg_emit_param_variable(LL_DebugInfo *db, SPTR sptr, int findex, int parnum,
     file_mdnode = lldbg_emit_file(db, findex);
   is_reference = ((SCG(sptr) == SC_DUMMY) && HOMEDG(sptr) && !PASSBYVALG(sptr));
   dtype = DTYPEG(sptr) ? DTYPEG(sptr) : DT_ADDR;
-  type_mdnode =
-      lldbg_emit_type(db, dtype, sptr, findex, is_reference, true, false);
+  if (ASSUMSHPG(sptr) && SDSCG(sptr)) {
+    type_mdnode = lldbg_emit_type(db, dtype, SDSCG(sptr), findex, is_reference,
+                                  true, false, sptr);
+  } else {
+    type_mdnode =
+        lldbg_emit_type(db, dtype, sptr, findex, is_reference, true, false);
+  }
   if (unnamed) {
     symname = NULL;
 #ifdef THISG
@@ -3666,7 +3762,8 @@ lldbg_create_cmblk_gv_mdnode(LL_DebugInfo *db, LL_MDRef cmnblk_mdnode,
   align[0] = 0;
   if (ll_feature_debug_info_ver11(&db->module->ir))
     subscript_mdnode = lldbg_create_subrange_mdnode(
-        db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub));
+        db, ll_get_md_i64(db->module, lb), ll_get_md_i64(db->module, ub),
+        ll_get_md_null());
   else
     subscript_mdnode = lldbg_create_subrange_mdnode_pre11(db, lb, sz);
   llmd_add_md(mdb, subscript_mdnode);
@@ -3716,7 +3813,7 @@ lldbg_create_common_block_mdnode(LL_DebugInfo *db, LL_MDRef scope,
 LL_MDRef
 lldbg_emit_common_block_mdnode(LL_DebugInfo *db, SPTR sptr)
 {
-  LL_MDRef scope_modnode, cmnblk_mdnode, cmnblk_gv_mdnode;
+  LL_MDRef scope_modnode, cmnblk_mdnode;
   SPTR scope = SCOPEG(sptr), var;
   const char *cmnblk_name = new_debug_name(SYMNAME(scope), SYMNAME(sptr), NULL);
   LL_MDNode *node;
@@ -3731,11 +3828,6 @@ lldbg_emit_common_block_mdnode(LL_DebugInfo *db, SPTR sptr)
   cmnblk_mdnode = lldbg_create_common_block_mdnode(
       db, scope_modnode, ll_get_md_null(), SYMNAME(sptr));
   db->cur_cmnblk_mdnode = cmnblk_mdnode;
-  cmnblk_gv_mdnode = lldbg_create_cmblk_gv_mdnode(db, cmnblk_mdnode, sptr);
-  slot = LL_MDREF_value(cmnblk_gv_mdnode) - 1;
-  node = db->module->mdnodes[slot];
-  cmnblk_gv_mdnode = node->elem[0];
-  ll_update_md_node(db->module, cmnblk_mdnode, 1, cmnblk_gv_mdnode);
   ll_add_module_debug(db->module->common_debug_map, cmnblk_name, cmnblk_mdnode);  
   if (db->cur_subprogram_mdnode)
     add_debug_cmnblk_variables(db, sptr);

--- a/tools/flang2/flang2exe/llutil.cpp
+++ b/tools/flang2/flang2exe/llutil.cpp
@@ -1422,57 +1422,16 @@ make_constsptr_op(SPTR sptr)
 static char *
 ll_get_string_buf(int string_len, char *base, int skip_quotes)
 {
-  char *name = "";
+  char *name;
   char *from, *to;
-  int c, len, newlen;
-
-  len = string_len;
-  from = base;
-  newlen = 3;
-  while (len--) {
-    c = *from++ & 0xff;
-    if (c == '\"' || c == '\\') {
-      newlen += 3;
-    } else if (c >= ' ' && c <= '~') {
-      newlen++;
-    } else if (c == '\n' || c == '\r') {
-      newlen += 3;
-    } else {
-      newlen += 3;
-    }
-  }
-  name = (char *)llutil_alloc((newlen + 3) * sizeof(char));
+  int len;
+  name = (char *)llutil_alloc(string_len * sizeof(char));
   to = name;
-  if (!skip_quotes) {
-    *name = '\"';
-    to++;
-  }
-
   from = base;
   len = string_len;
   while (len--) {
-    c = *from++ & 0xff;
-    if (c == '\"' || c == '\\') {
-      *to++ = '\\';
-      sprintf(to, "%02X", c);
-      to += 2;
-    } else if (c >= ' ' && c <= '~') {
-      *to++ = c;
-    } else if (c == '\n' || c == '\r') {
-      *to++ = '\\';
-      sprintf(to, "%02X", c);
-      to += 2;
-    } else {
-      *to++ = '\\';
-      sprintf(to, "%02X", c);
-      to += 3;
-    }
+    *to++ = *from++;
   }
-
-  if (!skip_quotes) {
-    *to++ = '\"';
-  }
-  *to = '\0';
   return name;
 }
 
@@ -2357,9 +2316,17 @@ write_operand(OPERAND *p, const char *punc_string, int flags)
       if (p->ll_type->sub_types[0]->data_type == LL_I16) {
           print_token(p->string);
       } else {
-          print_token("c\"");
-          print_token(p->string);
-          print_token("\"");
+        char buffer[6];
+        print_token("[");
+        for (int i = 0; i < p->ll_type->sub_elements; i++) {
+          if (i)
+            print_token(", ");
+          print_token("i8 ");
+          char c = p->string[i];
+          sprintf(buffer, "%d", c);
+          print_token(buffer);
+        }
+        print_token(" ] ");
       }
     }
     break;


### PR DESCRIPTION
Flang debuggability patch: (SWLCSG-369).  
Features/Fixes details:
    CPUPC-4434 - Support for -gpubnames in Flang
    [CPUPC-3884] Modified condition to check string not-null before using strncmp.
    [DebugInfo]Fix for CPUPC-3740: Debuggability of module variables defined in other files.
    [CPUPC-3100] Support for debug info of derived type pointer
    [CPUPC-4104] [SLN] [FLANG] common block name should not have debug info
    Fix for [CPUPC-4049] [SLN] flang gen exec doent show containing subprogram variable in gdb
    CPUPC-3925 fix for nwchem-6.8.1 -g build failure which is a regression caused due to 3252 fix
    CPUPC-4048 do not emit function return type as pointer type, if function is returning basic type
    CPUPC-4344, CPUPC-4345 - make XBIT(123,0x400) as default with -fopenmp and -g and reversal of this
    CPUPC-4415 - Fixed default emission of ".debug_names" section
    Fix for CPUPC-3759 flang is not able to represent constants of character type.
    [CPUPC-4100] [SLN] [FLANG] Support for debug info of pointer attributed array member of derived type
    Fix for [CPUPC-4054] [SLN][FLANG] Support for non-contiguous assumed shape array
    [CPUPC-3806] [SLN] debug support of pointer array associated to member of derived type.