### PR TITLE
Support for compilation specific wave size based on GPU architecture

### DIFF
--- a/tools/flang2/flang2exe/main.cpp
+++ b/tools/flang2/flang2exe/main.cpp
@@ -58,6 +58,7 @@
 #include <stdbool.h>
 #include "flang/ArgParser/arg_parser.h"
 #include "dtypeutl.h"
+#include <cmath>
 // AOCC BEGIN
 #ifdef DEBUG
 #include "debug.h"
@@ -740,6 +741,8 @@ init(int argc, char *argv[])
   register_string_arg(arg_parser, "std", &flg.std_string, "unknown");
   register_boolean_arg(arg_parser, "disable-vectorize-pragmas",
                        (bool *)&(flg.disable_loop_vectorize_pragmas), false);
+  register_integer_arg(arg_parser, "warp_size", &(flg.warp_size), 64);
+  register_string_arg(arg_parser, "march", &flg.march, NULL);
 
   // Debug Logs
 #ifdef DEBUG
@@ -816,6 +819,9 @@ init(int argc, char *argv[])
     interr("Erroneous -std option", 0, ERR_Fatal);
   }
   // AOCC end
+
+  warp_size_log2 = log2(flg.warp_size);
+  warp_size_log2_mask = flg.warp_size - 1;
 
   /* Free memory */
   destroy_arg_parser(&arg_parser);

--- a/tools/flang2/flang2exe/ompaccel.cpp
+++ b/tools/flang2/flang2exe/ompaccel.cpp
@@ -64,9 +64,8 @@
 #include "expreg.h"
 
 // Should be in sync with clang::GPU::AMDGPUGpuGridValues in clang
-#define GV_Warp_Size 64
-#define GV_Warp_Size_Log2 6
-#define GV_Warp_Size_Log2_Mask 63
+int warp_size_log2;
+int warp_size_log2_mask;
 // AOCC End
 #include "../../flang1/flang1exe/global.h"
 
@@ -905,7 +904,7 @@ ompaccel_nvvm_get(nvvm_sregs sreg)
     ll_process_routine_parameters(sptr);
     return ll_ad_outlined_func2(IL_DFRIR, IL_JSR, sptr, 0, nullptr);
   case warpSize:
-    return ad_icon(GV_Warp_Size);
+    return ad_icon(flg.warp_size);
   case blockDimX:
   case gridDimX:
     dim = 0;
@@ -2354,7 +2353,7 @@ ompaccel_nvvm_emit_inter_warp_copy(OMPACCEL_RED_SYM *ReductionItems,
 #endif
   if (flg.amdgcn_target) {
     sptrShmem = mk_ompaccel_addsymbol(
-        name, mk_ompaccel_array_dtype(DT_INT8, GV_Warp_Size),
+        name, mk_ompaccel_array_dtype(DT_INT8, flg.warp_size),
         SC_EXTERN, ST_ARRAY);
   } else {
   // AOCC End
@@ -2372,7 +2371,7 @@ ompaccel_nvvm_emit_inter_warp_copy(OMPACCEL_RED_SYM *ReductionItems,
   ili = ompaccel_nvvm_get(threadIdX);
   // AOCC Begin
   if (flg.amdgcn_target)
-    ili = mk_ompaccel_iand(ili, ad_icon(GV_Warp_Size_Log2_Mask));
+    ili = mk_ompaccel_iand(ili, ad_icon(warp_size_log2_mask));
   else
   // AOCC End
     ili = mk_ompaccel_iand(ili, ad_icon(31));
@@ -2385,7 +2384,7 @@ ompaccel_nvvm_emit_inter_warp_copy(OMPACCEL_RED_SYM *ReductionItems,
   ili = ompaccel_nvvm_get(threadIdX);
   // AOCC Begin
   if (flg.amdgcn_target)
-    ili = mk_ompaccel_shift(ili, DT_UINT, ad_icon(GV_Warp_Size_Log2), DT_UINT);
+    ili = mk_ompaccel_shift(ili, DT_UINT, ad_icon(warp_size_log2), DT_UINT);
   else
   //  AOCC End
     ili = mk_ompaccel_shift(ili, DT_UINT, ad_icon(5), DT_UINT);

--- a/tools/flang2/flang2exe/ompaccel.h
+++ b/tools/flang2/flang2exe/ompaccel.h
@@ -105,6 +105,10 @@ extern std::vector<OMPACCEL_TINFO *>  targetDataTinfos;
 
 extern OMPACCEL_TINFO **tinfos;
 
+extern int warp_size_log2;
+extern int warp_size_log2_mask;
+
+
 #define NVVM_WARPSIZE 32
 
 typedef enum NVVM_SREG_ENUM {

--- a/tools/flang2/flang2exe/ompaccel.h
+++ b/tools/flang2/flang2exe/ompaccel.h
@@ -108,7 +108,6 @@ extern OMPACCEL_TINFO **tinfos;
 extern int warp_size_log2;
 extern int warp_size_log2_mask;
 
-
 #define NVVM_WARPSIZE 32
 
 typedef enum NVVM_SREG_ENUM {

--- a/tools/flang2/flang2exe/x86_64-Linux/flgdf.h
+++ b/tools/flang2/flang2exe/x86_64-Linux/flgdf.h
@@ -61,6 +61,8 @@ FLG flg = {
     false,      /* omptarget - don't allow OpenMP Offload directives */
     25,         /* errorlimit */
     false,      /* trans_inv */
+    64,         /* Warp size for target */
+    NULL,       /* Arch of the omp target */
 #ifdef TARGET_X86
     0,                                     /* tpcount */
     0,          0, 0, 0, 0, 0, 0, 0, 0, 0, /* tpvalue */

--- a/tools/shared/utils/global.h
+++ b/tools/shared/utils/global.h
@@ -236,6 +236,8 @@ typedef struct {
   bool amdgcn_target; /*chech if we are offloading to amd gcn */
   bool x86_64_omptarget; /*chech if we are offloading to x86-64 */
   bool disable_loop_vectorize_pragmas; /* Disable Loop vecroizing pragmas */
+  int warp_size; /* Warp size for target */
+  char *march;  /* Arch of the omp target */
 #ifdef DEBUG
   LOGICAL debug_log; /* TRUE enables all debug log statements */
   char *debug_only_strs; /* enables only debug log categories in this string */


### PR DESCRIPTION
    flang2 compiler is now respecting the -warp_size flag
    The defult warp size is 64, for gfx10* warp is set to 32
    flang2 compiler is now respecting the -march flag