### PR TITLE
Unified Shared Memory patches from Shivarama

### DIFF
--- a/tools/flang1/flang1exe/ast.c
+++ b/tools/flang1/flang1exe/ast.c
@@ -5413,6 +5413,7 @@ ast_rewrite(int ast)
   case A_MP_EORDERED:
   case A_MP_ENDTASK:
   case A_MP_ETASKLOOP:
+  case A_MP_REQUIRESUNIFIEDSHAREDMEMORY: // AOCC
     break;
   case A_PREFETCH:
     lop = ast_rewrite(A_LOPG(ast));
@@ -6164,6 +6165,7 @@ ast_trav_recurse(int ast, int *extra_arg)
   case A_MP_TARGETDECLARE: // AOCC
   case A_MP_USE_DEVICE_PTR: // AOCC
   case A_MP_IS_DEVICE_PTR: // AOCC
+  case A_MP_REQUIRESUNIFIEDSHAREDMEMORY: // AOCC
     break;
   case A_MP_BMPSCOPE:
 #if DEBUG
@@ -6742,6 +6744,7 @@ _dump_one_ast(int i, FILE *file)
   case A_MP_BORDERED:
   case A_MP_EORDERED:
   case A_MP_FLUSH:
+  case A_MP_REQUIRESUNIFIEDSHAREDMEMORY: // AOCC
     break;
   case A_MP_PRE_TLS_COPY:
   case A_MP_COPYIN:
@@ -7181,6 +7184,7 @@ dump_ast_tree(int i)
   case A_MP_COPYPRIVATE:
   case A_MP_ECOPYPRIVATE:
   case A_MP_FLUSH:
+  case A_MP_REQUIRESUNIFIEDSHAREDMEMORY: // AOCC
     break;
   default:
     fprintf(gbl.dbgfil, "NO DUMP AVL");

--- a/tools/flang1/flang1exe/func.c
+++ b/tools/flang1/flang1exe/func.c
@@ -4435,6 +4435,7 @@ rewrite_calls(void)
     case A_MP_TASKREG:
     case A_MP_TASKDUP:
     case A_MP_ETASKDUP:
+    case A_MP_REQUIRESUNIFIEDSHAREDMEMORY: // AOCC
       break;
     case A_MP_TASKLOOPREG:
     case A_MP_ETASKLOOPREG:

--- a/tools/flang1/flang1exe/gbldefs.h
+++ b/tools/flang1/flang1exe/gbldefs.h
@@ -269,4 +269,19 @@ void fpp(void); /* fpp.c */
 #define snprintf _snprintf
 #endif
 
+enum OpenMPOffloadingRequiresDirFlags {
+  /// flag undefined.
+  OMP_REQ_UNDEFINED               = 0x000,
+  /// no requires clause present.
+  OMP_REQ_NONE                    = 0x001,
+  /// reverse_offload clause.
+  OMP_REQ_REVERSE_OFFLOAD         = 0x002,
+  /// unified_address clause.
+  OMP_REQ_UNIFIED_ADDRESS         = 0x004,
+  /// unified_shared_memory clause.
+  OMP_REQ_UNIFIED_SHARED_MEMORY   = 0x008,
+  /// dynamic_allocators clause.
+  OMP_REQ_DYNAMIC_ALLOCATORS      = 0x010
+};
+
 #endif /* FE_GBLDEFS_H */

--- a/tools/flang1/flang1exe/kwddf.h
+++ b/tools/flang1/flang1exe/kwddf.h
@@ -513,6 +513,7 @@ static KWORD t6[] = {
     {"teamsdistributesimd", TK_MP_TEAMSDISTSIMD},
     {"threadprivate", TK_MP_THREADPRIVATE},
     {"workshare", TK_MP_WORKSHARE},
+    {"requires", TK_MP_REQUIRES}, // AOCC
 };
 
 static KWORD t7[] = {

--- a/tools/flang1/flang1exe/lowerexp.c
+++ b/tools/flang1/flang1exe/lowerexp.c
@@ -5096,7 +5096,7 @@ lower_intrinsic(int ast)
   return ilm;
 } /* lower_intrinsic */
 
-#if AST_MAX != 169 // AOCC - 167 + 1 + 1
+#if AST_MAX != 170 // AOCC - 170 + 1 + 1
 #error "Need to edit lowerexp.c to add or delete A_... AST types"
 #endif
 
@@ -6104,6 +6104,7 @@ lower_ast(int ast, int *unused)
   case A_MP_ATOMICCAPTURE:
   case A_MP_USE_DEVICE_PTR:
   case A_MP_IS_DEVICE_PTR:  // AOCC
+  case A_MP_REQUIRESUNIFIEDSHAREDMEMORY: // AOCC
   default:
     ast_error("bad ast optype in expression", ast);
     break;

--- a/tools/flang1/flang1exe/lowerilm.c
+++ b/tools/flang1/flang1exe/lowerilm.c
@@ -5146,6 +5146,14 @@ lower_stmt(int std, int ast, int lineno, int label)
     lower_end_stmt(std);
     break;
 
+  case A_MP_REQUIRESUNIFIEDSHAREDMEMORY:
+    lower_start_stmt(lineno, label, TRUE, std);
+    // requires with clause usm is dumped with value (8)
+    // for other require clauses, appt values need to be dumped
+    plower("on", "REQUIRES", OMP_REQ_UNIFIED_SHARED_MEMORY);
+    lower_end_stmt(std);
+    break;
+
   case A_MP_TASK:
   case A_MP_TASKLOOP:
     lowersym.task_depth++;

--- a/tools/flang1/flang1exe/parser.c
+++ b/tools/flang1/flang1exe/parser.c
@@ -696,6 +696,14 @@ prettytoken(int tkntyp, INT tknval)
   case TK_MP_PDO:
     sprintf(symbuf, "DO");
     break;
+  // AOCC Begin
+  case TK_MP_REQUIRES:
+    sprintf(symbuf, "%s", "REQUIRES");
+    break;
+  case TK_MP_REQUIRESUNIFIEDSHAREDMEMORY:
+    sprintf(symbuf, "%s", "REQUIRES UNIFIED_SHARED_MEMORY");
+    break;
+  // AOCC End
   case TK_MP_SECTION:
     sprintf(symbuf, "SECTION");
     break;

--- a/tools/flang1/flang1exe/rest.c
+++ b/tools/flang1/flang1exe/rest.c
@@ -365,6 +365,7 @@ insert_comm_before(int std, int ast, LOGICAL *rhs_is_dist, LOGICAL is_subscript)
   case A_MP_TARGETDECLARE: // AOCC
   case A_MP_USE_DEVICE_PTR: // AOCC
   case A_MP_IS_DEVICE_PTR: // AOCC
+  case A_MP_REQUIRESUNIFIEDSHAREDMEMORY: // AOCC
     return a;
   default:
     interr("insert_comm_before: unknown expression", std, 2);
@@ -4332,6 +4333,7 @@ transform_all_call(int std, int ast)
   case A_MP_TARGETDECLARE: // AOCC
   case A_MP_USE_DEVICE_PTR: // AOCC
   case A_MP_IS_DEVICE_PTR: // AOCC
+  case A_MP_REQUIRESUNIFIEDSHAREDMEMORY: // AOCC
     return a;
   case A_PRAGMA:
     return a;

--- a/tools/flang1/flang1exe/scan.c
+++ b/tools/flang1/flang1exe/scan.c
@@ -3555,6 +3555,22 @@ classify_smp(void)
       scmode = SCM_PAR;
       break;
     }
+
+  case TK_MP_REQUIRES: {
+      int savecp = cp;
+      while (cp && *cp == ' ') cp++;
+      if (is_ident(cp) && strncmp(cp, "unified_shared_memory", 21) == 0) {
+        cp += 21;
+        scn.stmtyp = tkntyp = TK_MP_REQUIRESUNIFIEDSHAREDMEMORY;
+        scmode = SCM_PAR;
+      } else {
+        scn.stmtyp = tkntyp = TK_MP_REQUIRES;
+        scmode = SCM_PAR;
+	cp=savecp;
+      }
+      break;
+    }
+
   case TK_MP_TASKLOOP:
 taskloop:
     if ((*cp == ' ' && (is_ident(cp + 1)) &&

--- a/tools/flang1/flang1exe/semsmp.c
+++ b/tools/flang1/flang1exe/semsmp.c
@@ -2306,6 +2306,14 @@ semsmp(int rednum, SST *top)
     SST_ASTP(LHS, 0);
     break;
 
+  /* AOCC
+   *	<mp stmt> ::= <mp requires unified_shared_memory>
+   */
+  case MP_STMT93:
+    ast = mk_stmt(A_MP_REQUIRESUNIFIEDSHAREDMEMORY, 0);
+    SST_ASTP(LHS, ast);
+    break;
+
   /* ------------------------------------------------------------------ */
   /*
    *	<opt csident> ::= |

--- a/tools/flang1/utils/ast/ast.n
+++ b/tools/flang1/utils/ast/ast.n
@@ -3136,6 +3136,9 @@ AST pointer to the corresponding \f(CWA_MP_ENDTASK\fP.
 .SM MP_TASKLOOP
 .SI "taskloop"
 .lp
+.SM MP_REQUIRESUNIFIEDSHAREDMEMORY
+.SI "requiresunifiedsharedmemory"
+.lp
 OpenMP taskloop directive.
 .lp
 .ul

--- a/tools/flang1/utils/prstab/gram.tki
+++ b/tools/flang1/utils/prstab/gram.tki
@@ -497,6 +497,8 @@ COPY        TK_COPY
 <mp targteamsdistpardosimd> TK_MP_TARGTEAMSDISTPARDOSIMD
 <mp targteamsdistsimd> TK_MP_TARGTEAMSDISTSIMD
 <mp task>	          TK_MP_TASK
+<mp requires>	          TK_MP_REQUIRES
+<mp requiresunifiedsharedmemory>  TK_MP_REQUIRESUNIFIEDSHAREDMEMORY
 <mp taskgroup>	    TK_MP_TASKGROUP
 <mp taskloop>	      TK_MP_TASKLOOP
 <mp taskloopsimd>	  TK_MP_TASKLOOPSIMD

--- a/tools/flang1/utils/prstab/gram.txt
+++ b/tools/flang1/utils/prstab/gram.txt
@@ -1794,7 +1794,9 @@
 		<mp endtargteamsdistpardosimd> |
                 <mp taskgroup> |
                 <mp endtaskgroup> |
-                <mp cancellationpoint> <id name>
+                <mp cancellationpoint> <id name>  |
+                <mp requiresunifiedsharedmemory>
+
 
 <opt csident> ::= |
 		  ( <id name> )

--- a/tools/flang2/flang2exe/expsmp.cpp
+++ b/tools/flang2/flang2exe/expsmp.cpp
@@ -66,6 +66,7 @@ inline SPTR GetPARUPLEVEL(SPTR sptr) {
 #include <iterator>
 static bool in_parallel = false;
 std::list<int> targetVector;
+int HasRequiresUnifiedSharedMemory = false;
 // AOCC End
 
 static int incrOutlinedCnt(void);
@@ -1545,6 +1546,7 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
       iltb.callfg = 1;
       chk_block(ili);
     }
+
     // AOCC End
     wr_block();
     cr_block();
@@ -2785,6 +2787,14 @@ exp_smp(ILM_OP opc, ILM *ilmp, int curilm)
     iltb.callfg = 1;
     chk_block(ili);
     break;
+
+  case IM_REQUIRES: {
+    int requireClause = ILM_OPND(ilmp,1);
+    if (requireClause == OMP_REQ_UNIFIED_SHARED_MEMORY) {
+      HasRequiresUnifiedSharedMemory = true;
+    }
+    break;
+  }
 
   case IM_BMPPG:
     if (ll_ilm_is_rewriting())

--- a/tools/flang2/flang2exe/main.cpp
+++ b/tools/flang2/flang2exe/main.cpp
@@ -72,6 +72,7 @@ static bool process_input(char *argv0, bool *need_cuda_constructor);
 extern int errno;
 #endif
 #endif
+extern int HasRequiresUnifiedSharedMemory;
 
 #define IS_COFF (flg.astype == 1)
 #define IS_ELF (flg.astype == 0)
@@ -482,15 +483,13 @@ main(int argc, char *argv[])
   upper_init();
   if (!findex)
     gbl.findex = addfile(gbl.file_name, NULL, 0, 0, 0, 1, 0);
-#if 0
 #ifdef OMP_OFFLOAD_LLVM
   if (flg.omptarget) {
     init_test();
-    ompaccel_create_globalctor();
+ // ompaccel_create_globalctor();
     gbl.func_count--;
     gbl.multi_func_count = gbl.func_count;
   }
-#endif
 #endif
   do { /* loop once for each user program unit */
 
@@ -499,6 +498,10 @@ main(int argc, char *argv[])
 
   } while (!gbl.eof_flag);
 
+
+  if (flg.omptarget) {
+    ompaccel_create_globalctor();
+  }
   cg_llvm_end();
 
   if (flg.smp) {

--- a/tools/flang2/flang2exe/tgtutil.cpp
+++ b/tools/flang2/flang2exe/tgtutil.cpp
@@ -74,6 +74,7 @@ static SPTR init_tgt_target_syms(const char *kernelname, SPTR sptr = SPTR_NULL);
 int dataregion = 0;
 
 static DTYPE tgt_offload_entry_type = DT_NONE;
+extern int HasRequiresUnifiedSharedMemory;
 
 /* Flags for use with the entry */
 #define DT_VOID_NONE DT_NONE
@@ -1108,7 +1109,7 @@ init_tgt_register_syms()
   // tptr1 = (SPTR)addnewsym(".omp_offloading.entries_begin"); // AOCC
   tptr1 = (SPTR)addnewsym("__start_omp_offloading_entries"); // AOCC
   // AOCC Begin
-  tgt_offload_entry_type = ll_make_tgt_offload_entry("__tgt_offload_entry_");
+  tgt_offload_entry_type = ll_make_tgt_offload_entry("__tgt_offload_entry_type_");
   // AOCC End
   DTYPEP(tptr1, tgt_offload_entry_type);
   /* SCP(tptr1, SC_EXTERN); */ SCP(tptr1, SC_PRIVATE); // AOCC
@@ -1200,7 +1201,7 @@ ll_make_tgt_register_requires()
   DTYPE dtype_bindesc, dtype_entry, dtype_devimage, dtype_pofbindesc;
 
   // AOCC Begin
-  tgt_offload_entry_type = ll_make_tgt_offload_entry("__tgt_offload_entry_");
+  tgt_offload_entry_type = ll_make_tgt_offload_entry("__tgt_offload_entry_requires_");
   // AOCC End
   dtype_entry = tgt_offload_entry_type;
   dtype_devimage = ll_make_tgt_device_image("__tgt_device_image", dtype_entry);
@@ -1215,7 +1216,11 @@ ll_make_tgt_register_requires()
 
   int args[1];
   DTYPE arg_types[1] = {DT_INT8};
-  args[0] = ad_kconi(1);
+  if (HasRequiresUnifiedSharedMemory) {
+    args[0] = ad_kconi(OMP_REQ_UNIFIED_SHARED_MEMORY);
+  }
+  else
+    args[0] = ad_kconi(1);
   return mk_tgt_api_call(TGT_API_REGISTER_REQUIRES, 1, arg_types, args);
 }
 // AOCC end
@@ -1252,7 +1257,7 @@ ll_make_tgt_register_lib2()
          "OpenMP Offload structures are not found.", 0, ERR_Fatal);
   // AOCC end
 
-  dtype_entry = ll_make_tgt_offload_entry("__tgt_offload_entry"); //AOCC
+  dtype_entry = ll_make_tgt_offload_entry("__tgt_offload_entry_lib2_"); //AOCC
   dtype_devimage = ll_make_tgt_device_image("__tgt_device_image", dtype_entry);
   dtype_bindesc =
       ll_make_tgt_bin_descriptor("__tgt_bin_desc", dtype_entry, dtype_devimage);
@@ -1344,7 +1349,7 @@ ll_make_tgt_register_lib2()
 void
 init_tgtutil()
 {
-  tgt_offload_entry_type = ll_make_tgt_offload_entry("__tgt_offload_entry_");
+  tgt_offload_entry_type = ll_make_tgt_offload_entry("__tgt_offload_entry_type_");
 }
 
 // AOCC Begin

--- a/tools/flang2/flang2exe/tgtutil.h
+++ b/tools/flang2/flang2exe/tgtutil.h
@@ -49,6 +49,22 @@ enum {
   TGT_API_N_ENTRIES /* <-- Always last */
 };
 
+enum OpenMPOffloadingRequiresDirFlags : int64_t {
+  /// flag undefined.
+  OMP_REQ_UNDEFINED               = 0x000,
+  /// no requires clause present.
+  OMP_REQ_NONE                    = 0x001,
+  /// reverse_offload clause.
+  OMP_REQ_REVERSE_OFFLOAD         = 0x002,
+  /// unified_address clause.
+  OMP_REQ_UNIFIED_ADDRESS         = 0x004,
+  /// unified_shared_memory clause.
+  OMP_REQ_UNIFIED_SHARED_MEMORY   = 0x008,
+  /// dynamic_allocators clause.
+  OMP_REQ_DYNAMIC_ALLOCATORS      = 0x010
+};
+
+
 typedef struct any_tgt_struct {
   char *name;
   DTYPE dtype;

--- a/tools/flang2/utils/ilmtp/aarch64/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/aarch64/ilmtp.n
@@ -3365,6 +3365,8 @@ sym - upperD
 stc -  dtype of loop bound type
 stc -  schedule type
 .AT spec trm
+.IL REQUIRES stc
+.AT spec trm
 .IL BTASKDUP SMP
 Begin taskdup routine
 .AT spec trm

--- a/tools/flang2/utils/ilmtp/ppc64le/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/ppc64le/ilmtp.n
@@ -3364,6 +3364,8 @@ sym - upperD
 stc -  dtype of loop bound type
 stc -  schedule type
 .AT spec trm
+.IL REQUIRES stc
+.AT spec trm
 .IL BTASKDUP SMP
 Begin taskdup routine
 .AT spec trm

--- a/tools/flang2/utils/ilmtp/x86_64/ilmtp.n
+++ b/tools/flang2/utils/ilmtp/x86_64/ilmtp.n
@@ -3851,6 +3851,8 @@ Task firstprivate
 sym - symbol table pointer to the shared variable.
 sym - symbol table pointer to the private copy.
 .AT spec trm
+.IL REQUIRES SMP stc
+.AT spec trm
 .IL BTASK SMP sym stc lnk lnk
 Begin task
 Always matches a ETASK ilm

--- a/tools/flang2/utils/upper/upperilm.in
+++ b/tools/flang2/utils/upper/upperilm.in
@@ -114,6 +114,7 @@ BRF	ilm	sym
 BRT	ilm	sym
 BDISTRIBUTE
 BSECTIONS	sym
+REQUIRES num
 BTASK	sym	num	ilm	ilm
 BTASKDUP
 BTASKLOOP	sym	num	ilm	ilm	ilm 	ilm


### PR DESCRIPTION
WIP, needs to resolve extraneous CTOR causing a NOT an ELF Image message
any flang test for target produces it.

smoke-fails/usm1  is a  reference for what C produces

good place to breakpoint
 elf_check_machine(__tgt_device_image*, uint16_t)
llvm-project/openmp/libomptarget/plugins/common/elf_common/elf_common.cpp:71

