### PR TITLE
Update kernel execution mode

### DIFF
--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -14401,7 +14401,7 @@ INLINE void static add_property_struct(char *func_name, int nreductions,
 {
   print_token("@");
   print_token(func_name);
-  print_token("__exec_mode = weak constant i8 0\n");
+  print_token("__exec_mode = weak constant i8 2\n");
 }
 #endif
 


### PR DESCRIPTION
Flang kernels are launched as SPMD kernels.
Value which describes SPMD kernel execution mode was changed from 0 to 2 in OpenMP runtime.

The OpenMP runtime change is described here:
https://reviews.llvm.org/D110029

Signed-off-by: Dominik Adamski <Dominik.Adamski@amd.com>