### PR TITLE
fixing runtime issues

### DIFF
--- a/tools/flang2/flang2exe/ll_ftn.cpp
+++ b/tools/flang2/flang2exe/ll_ftn.cpp
@@ -449,7 +449,8 @@ ll_process_routine_parameters(SPTR func_sptr)
         }
         /* For string, need to ut length */
         if (!PASSBYVALG(param_sptr) &&
-            (DTYG(param_dtype) == TY_CHAR || DTYG(param_dtype) == TY_NCHAR)) {
+            (DTYG(param_dtype) == TY_CHAR || DTYG(param_dtype) == TY_NCHAR) &&
+            !OMPACCDEVSYMG(param_sptr)) {
           SPTR len = CLENG(param_sptr);
           if ((len <= NOSYM) || (SCG(len) == SC_NONE) ||
               (SCG(len) == SC_LOCAL)) {

--- a/tools/flang2/flang2exe/tgtutil.cpp
+++ b/tools/flang2/flang2exe/tgtutil.cpp
@@ -347,7 +347,7 @@ _tgt_target_fill_size(SPTR sptr, int map_type, int base_ili)
           } else {
             ilix = ad3ili(IL_LD, ad_acon(sdsc, 48), nme, MSZ_WORD);
           }
-          ilix = ad2ili(IL_KMUL, ilix, ad_kconi(size_of((DTYPE)(dtype + 1))));
+          ilix = ad2ili(IL_KMUL, ilix, ad_kconi(size_of(DTySeqTyElement(dtype))));
           return ilix;
         }
 #endif
@@ -365,7 +365,7 @@ _tgt_target_fill_size(SPTR sptr, int map_type, int base_ili)
           ilix = ad2ili(IL_KMUL, ilix, rilix);
         }
         if (DTY( (DTYPE) DTY((DTYPE) (dtype + 1))) != TY_STRUCT)  // AOCC
-          ilix = ad2ili(IL_KMUL, ilix, ad_kconi(size_of((DTYPE)(dtype + 1))));
+          ilix = ad2ili(IL_KMUL, ilix, ad_kconi(size_of(DTySeqTyElement(dtype))));
         // AOCC Begin
         else
           ilix = ad2ili(IL_KMUL, ilix,


### PR DESCRIPTION
1. One issue is because of an unnecessary argument in the outlined
function. It is fixed with the changes in ll_ftn.cpp

2. Other is caused because wrong size of char is mapped. 8 bytes are
mapped for char instead of 1 byte. It is fixed with the changes in
tgtutil.cpp