### PR TITLE
Unify initialization procedure.

### DIFF
--- a/tools/flang2/flang2exe/expand.cpp
+++ b/tools/flang2/flang2exe/expand.cpp
@@ -688,40 +688,40 @@ eval_ilm(int ilmx)
      * sharing model. It does extra work and allocates device on-chip memory.
      * */
     if (XBIT(232, 0x40) && gbl.ompaccel_intarget) {
-      ilix = ompaccel_nvvm_get(threadIdX);
-      ilix = ll_make_kmpc_target_init(ilix,
-                                      ompaccel_tinfo_get(gbl.currsub)->mode);
-      iltb.callfg = 1;
+      ilix = ll_make_kmpc_target_init(ompaccel_tinfo_get(gbl.currsub)->mode);
+
       /* Generate new control flow for generic kernel */
+      target_code_lab = getlab();
+      exit_code_lab = getlab();
+      ilix = ad4ili(IL_ICJMP, ilix, ad_icon(-1), CC_EQ, target_code_lab);
+
+      /* Write block which contains OpenMP initialization call */
+      chk_block(ilix);
+      wr_block();
+      cr_block();
+
+      /* Create and write block which contains return instruction. */
+      RFCNTI(exit_code_lab);
+      exp_label(exit_code_lab);
+      expb.curilt = addilt(expb.curilt, ad1ili(IL_EXIT, gbl.currsub));
+      BIH_XT(expb.curbih) = 1;
+      BIH_LAST(expb.curbih) = 1;
+      wr_block();
+
+      /* Create and set as active block where target pragma code
+       * will be located  */
+      RFCNTI(target_code_lab);
+      exp_label(target_code_lab);
+
       if (is_SPMD_mode(ompaccel_tinfo_get(gbl.currsub)->mode)) {
-        chk_block(ilix);
-      } else {
-        target_code_lab = getlab();
-        exit_code_lab = getlab();
-        ilix = ad4ili(IL_ICJMP, ilix, ad_icon(-1), CC_EQ, target_code_lab);
-
-        /* Write block which contains OpenMP initialization call */
-        chk_block(ilix);
-        wr_block();
-        cr_block();
-
-        /* Create and write block which contains return instruction. */
-        RFCNTI(exit_code_lab);
-        exp_label(exit_code_lab);
-        expb.curilt = addilt(expb.curilt, ad1ili(IL_EXIT, gbl.currsub));
-        BIH_XT(expb.curbih) = 1;
-        BIH_LAST(expb.curbih) = 1;
-        wr_block();
-
-        /* Create and set as active block where target pragma code
-         * will be located  */
-        RFCNTI(target_code_lab);
-        exp_label(target_code_lab);
-
         iltb.callfg = 1;
-        wr_block();
-        cr_block();
+        ilix = ll_make_kmpc_global_thread_num();
+        chk_block(ilix);
       }
+
+      iltb.callfg = 1;
+      wr_block();
+      cr_block();
     }
   }
 #endif

--- a/tools/flang2/flang2exe/kmpcutil.cpp
+++ b/tools/flang2/flang2exe/kmpcutil.cpp
@@ -1723,81 +1723,43 @@ ll_make_kmpc_kernel_init_params(int ReductionScratchpadPtr)
   return mk_kmpc_api_call(KMPC_API_KERNEL_INIT_PARAMS, 1, arg_types, args);
 }
 
-static int
-gen_int_arg(DTYPE dt, int value)
-{
-  int con, ili;
-  INT tmp[2];
-
-  tmp[0] = 0;
-  tmp[1] = value;
-  con = getcon(tmp, dt);
-  ili = ad1ili(IL_ACON, con);
-  return ili;
-}
-
-static int
-ll_make_kmpc_generic_target_init()
-{
-  int args[4];
-  DTYPE arg_types[4] = {DT_CPTR, DT_BLOG, DT_BLOG, DT_BLOG};
-  args[3] = gen_null_arg();
-  args[2] = gen_int_arg(DT_BLOG, 1);
-  args[1] = gen_int_arg(DT_BLOG, 1);
-  args[0] = gen_int_arg(DT_BLOG, 1);
-  return mk_kmpc_api_call(KMPC_API_TARGET_INIT, 4, arg_types, args);
-}
-
-static int
-ll_make_kmpc_spmd_target_init(int sptr)
-{
-  int args[3];
-  DTYPE arg_types[3] = {DT_INT, DT_SINT, DT_SINT};
-  args[2] = sptr; // ld_sptr(sptr);
-  args[1] = gen_null_arg();
-  args[0] = gen_null_arg();
-  return mk_kmpc_api_call(KMPC_API_SPMD_KERNEL_INIT, 3, arg_types, args);
-}
-
 int
-ll_make_kmpc_target_init(int sptr, OMP_TARGET_MODE mode)
+ll_make_kmpc_target_init(OMP_TARGET_MODE mode)
 {
+  DTYPE arg_types[4] = {DT_CPTR, DT_BLOG, DT_BLOG, DT_BLOG};
+  int args[4];
+
+  args[3] = gen_null_arg(); /* ident */
   if (is_SPMD_mode(mode)) {
-    return ll_make_kmpc_spmd_target_init(sptr);
+    args[2] = ad_icon(2); /* SPMD Mode */
+    args[1] = ad_icon(0); /* UseGenericStateMachine */
+    args[0] = ad_icon(0); /* RequiresFullRuntime */
+  } else {
+    args[2] = ad_icon(1); /* Generic mode */
+    args[1] = ad_icon(1); /* UseGenericStateMachine */
+    args[0] = ad_icon(1); /* RequiresFullRuntime */
   }
-  return ll_make_kmpc_generic_target_init();
+  return mk_kmpc_api_call(KMPC_API_TARGET_INIT, 4, arg_types, args);
 }
 
 // AOCC Begin
 #ifdef OMP_OFFLOAD_AMD
-static int
-ll_make_kmpc_spmd_target_deinit_v2()
-{
-  int args[1];
-  DTYPE arg_types[3] = {DT_SINT};
-  args[0] = gen_null_arg();
-  return mk_kmpc_api_call(KMPC_API_SPMD_KERNEL_DEINIT_V2, 1, arg_types, args);
-}
-
-static int
-ll_make_kmpc_generic_target_deinit()
-{
-  int args[3];
-  DTYPE arg_types[3] = {DT_CPTR, DT_BLOG, DT_BLOG};
-  args[2] = gen_null_arg();
-  args[1] = gen_int_arg(DT_BLOG, 1);
-  args[0] = gen_int_arg(DT_BLOG, 1);
-
-  return mk_kmpc_api_call(KMPC_API_TARGET_DEINIT, 3, arg_types, args);
-}
 
 int
 ll_make_kmpc_target_deinit(OMP_TARGET_MODE mode)
 {
+  DTYPE arg_types[3] = {DT_CPTR, DT_BLOG, DT_BLOG};
+  int args[3];
+
+  args[2] = gen_null_arg(); /* ident */
   if (is_SPMD_mode(mode)) {
-    return ll_make_kmpc_spmd_target_deinit_v2();
+    args[1] = ad_icon(2); /* SPMD Mode */
+    args[0] = ad_icon(0); /* RequiresFullRuntime */
+  } else {
+    args[1] = ad_icon(1); /* Generic mode */
+    args[0] = ad_icon(1); /* RequiresFullRuntime */
   }
-  return ll_make_kmpc_generic_target_deinit();
+  return mk_kmpc_api_call(KMPC_API_TARGET_DEINIT, 3, arg_types, args);
 }
 #endif
 // AOCC End

--- a/tools/flang2/flang2exe/kmpcutil.h
+++ b/tools/flang2/flang2exe/kmpcutil.h
@@ -500,7 +500,7 @@ int ll_make_kmpc_for_static_init_simple_spmd(const loop_args_t *, int);
 /**
   \brief kernel init
 */
-int ll_make_kmpc_target_init(int, OMP_TARGET_MODE);
+int ll_make_kmpc_target_init(OMP_TARGET_MODE);
 
 // AOCC Begin
 #ifdef OMP_OFFLOAD_AMD

--- a/tools/flang2/flang2exe/ompaccel.cpp
+++ b/tools/flang2/flang2exe/ompaccel.cpp
@@ -2602,9 +2602,7 @@ exp_ompaccel_bpar(ILM *ilmp, int curilm, SPTR uplevel_sptr, SPTR scopeSptr,
 
     // AOCC begin
     if (!flg.x86_64_omptarget) {
-      ili = ompaccel_nvvm_get(threadIdX);
-      ili = ll_make_kmpc_target_init(ili,
-                                     ompaccel_tinfo_get(gbl.currsub)->mode);
+      ili = ll_make_kmpc_target_init(ompaccel_tinfo_get(gbl.currsub)->mode);
       iltb.callfg = 1;
       chk_block(ili);
     }
@@ -3274,9 +3272,7 @@ exp_ompaccel_bteams(ILM *ilmp, int curilm, int outlinedCnt, SPTR uplevel_sptr,
     if (flg.omptarget) {
       // AOCC begin
       if (!flg.x86_64_omptarget) {
-        ili = ompaccel_nvvm_get(threadIdX);
-        ili = ll_make_kmpc_target_init(ili,
-                                       ompaccel_tinfo_get(gbl.currsub)->mode);
+        ili = ll_make_kmpc_target_init(ompaccel_tinfo_get(gbl.currsub)->mode);
         iltb.callfg = 1;
         chk_block(ili);
       }


### PR DESCRIPTION
Remove __kmpc_spmd_kernel_init and __kmpc_spmd_kernel_deinit
calls. Use __kmpc_target_init_v1 and __kmpc_target_deinit_v1 instead.

Signed-off-by: Dominik Adamski <Dominik.Adamski@amd.com>