### PR TITLE
Add -Wno-implicit-int to CMake C Flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,11 +289,11 @@ else()
   set(FLANG_HAS_VERSION_PATCHLEVEL 0)
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon -Wno-implicit-function-declaration")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon -Wno-implicit-function-declaration -Wno-implicit-int")
 
 # Add appropriate flags for GCC
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -g -DOMP_OFFLOAD_LLVM -Wno-implicit-function-declaration")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -g -DOMP_OFFLOAD_LLVM -Wno-implicit-function-declaration -Wno-implicit-int")
   option(WITH_WERROR "Compile with '-Werror' C compiler flag" ON)
   if (WITH_WERROR)
 	  # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")


### PR DESCRIPTION
It is required for newer compilers enforcing C99 standard.