### PR TITLE
Use find_library instead of -l to find libquadmath.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,8 @@ if (APPLE)
   set(CMAKE_MODULE_LINKER_FLAGS "-Wl,-flat_namespace -Wl,-undefined -Wl,suppress")
 endif ()
 
+find_library(LIBQUADMATH_LOC quadmath NAMES libquadmath.so libquadmath.so.0 REQUIRED)
+
 macro(add_flang_library name)
   llvm_process_sources(srcs ${ARGN})
   if (MODULE)
@@ -329,7 +331,7 @@ macro(add_flang_library name)
   endif( LLVM_COMMON_DEPENDS )
 
   llvm_config( ${name} ${LLVM_LINK_COMPONENTS} )
-  target_link_libraries( ${name} ${LLVM_COMMON_LIBS} -lquadmath)
+  target_link_libraries( ${name} ${LLVM_COMMON_LIBS} ${LIBQUADMATH_LOC})
 #  link_system_libs( ${name} )  # getd of cmake warning messages
 
   install(TARGETS ${name}

--- a/runtime/flangrti/CMakeLists.txt
+++ b/runtime/flangrti/CMakeLists.txt
@@ -107,7 +107,7 @@ find_library(
   libpgmath.so
   HINTS ${CMAKE_BINARY_DIR}/lib)
 target_link_libraries(flangrti_shared ${LIBPGMATH} -Wl,-rpath,\$ORIGIN)
-target_link_libraries(flangrti_shared quadmath)
+target_link_libraries(flangrti_shared ${LIBQUADMATH_LOC})
 
 if( ${TARGET_ARCHITECTURE} STREQUAL "aarch64" )
   target_compile_definitions(flangrti_static PRIVATE TARGET_LINUX_ARM)


### PR DESCRIPTION
Centos-9 had an issue where this library was not
being found. We should instead use find_library
to allow certain names to be searched in case
the OS does not have a libquadmath.so symlink.
The build will now fail in the cmake step if
quadmath is not found.