### PR TITLE
Do not attach attributes to kernel functions

### DIFF
--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -13828,19 +13828,6 @@ write_external_function_declarations(int first_time)
   DBGTRACEOUT("");
 } /* write_external_function_declarations */
 
-// AOCC Begin
-#ifdef OMP_OFFLOAD_LLVM
-INLINE static void write_kernel_attributes(FILE *out) {
-  if (flg.amdgcn_target) {
-    // We are not generating any debug info for GPU(as of now),
-    // so #0 won't be duplicated.
-    fprintf(out,
-        "attributes #0 = { \"amdgpu-flat-work-group-size\"=\"256,256\" }\n");
-  }
-}
-#endif
-// AOCC End
-
 /**
    \brief Emit function attributes in debugging mode output
 
@@ -14356,11 +14343,6 @@ print_function_signature(int func_sptr, const char *fn_name, LL_ABI_Info *abi,
 
   print_token(")");
 
-#ifdef OMP_OFFLOAD_AMD
-  if (flg.amdgcn_target && OMPACCFUNCKERNELG(gbl.currsub))
-    print_token(" #0");
-#endif
-
   /* Function attributes.  With debugging turned on, the debug attributes
      contain "noinline", so there is no need to repeat it here. */
   if (need_debug_info(SPTR_NULL)) {
@@ -14785,7 +14767,6 @@ cg_llvm_end(void)
   if (flg.omptarget) {
     ll_build_metadata_device(gbl.ompaccfile, gpu_llvm_module);
     ll_write_metadata(gbl.ompaccfile, gpu_llvm_module);
-    write_kernel_attributes(gbl.ompaccfile); // AOCC
   }
 #endif
 }


### PR DESCRIPTION
Flang adds hardcoded attribute to kernel functions: amdgpu-flat-work-group-size="256,256" . This attribute
can cause wrong program execution especially when hardcoded work group size attribute does not correspond to work group size used in OpenMP runtime.

Signed-off-by: Dominik Adamski <dominik.adamski@amd.com>