### PR TITLE
[SWDEV-318074] Fix undefined references to modulo functions in target region

### DIFF
--- a/runtime/flang/miscsup_com.c
+++ b/runtime/flang/miscsup_com.c
@@ -4018,6 +4018,12 @@ ENTF90(MODULOv, modulov)(__INT4_T a, __INT4_T p)
   return r;
 }
 
+__INT4_T
+__ENTF90(MODULOv, modulov)(__INT4_T a, __INT4_T p)
+{
+  return ENTF90(MODULOv, modulov)(a, p);
+}
+
 __INT8_T
 ENTF90(I8MODULOv, i8modulov)(__INT8_T a, __INT8_T p)
 {
@@ -4029,6 +4035,12 @@ ENTF90(I8MODULOv, i8modulov)(__INT8_T a, __INT8_T p)
     r += (p);
   }
   return r;
+}
+
+__INT8_T
+__ENTF90(I8MODULOv, i8modulov)(__INT8_T a, __INT8_T p)
+{
+  return ENTF90(I8MODULOv, i8modulov)(a, p);
 }
 
 __INT2_T
@@ -4044,6 +4056,12 @@ ENTF90(IMODULOv, imodulov)(__INT2_T a, __INT2_T p)
   return r;
 }
 
+__INT2_T
+__ENTF90(IMODULOv, imodulov)(__INT2_T a, __INT2_T p)
+{
+  return ENTF90(IMODULOv, imodulov)(a, p);
+}
+
 __REAL_T
 ENTF90(AMODULOv, amodulov)(__REAL_T x, __REAL_T y)
 {
@@ -4052,6 +4070,12 @@ ENTF90(AMODULOv, amodulov)(__REAL_T x, __REAL_T y)
   if (d != 0 && ((x < 0 && y > 0) || (x > 0 && y < 0)))
     d += y;
   return d;
+}
+
+__REAL_T
+__ENTF90(AMODULOv, amodulov)(__REAL_T x, __REAL_T y)
+{
+  return ENTF90(AMODULOv, amodulov)(x, y);
 }
 
 __DBLE_T
@@ -4064,6 +4088,12 @@ ENTF90(DMODULOv, dmodulov)(__DBLE_T x, __DBLE_T y)
   return d;
 }
 
+__DBLE_T
+__ENTF90(DMODULOv, dmodulov)(__DBLE_T x, __DBLE_T y)
+{
+  return ENTF90(DMODULOv, dmodulov)(x, y);
+}
+
 // AOCC Begin
 __REAL16_T
 ENTF90(QMODULOv, qmodulov)(__REAL16_T x, __REAL16_T y)
@@ -4073,6 +4103,12 @@ ENTF90(QMODULOv, qmodulov)(__REAL16_T x, __REAL16_T y)
   if (d != 0 && ((x < 0 && y > 0) || (x > 0 && y < 0)))
     d += y;
   return d;
+}
+
+__REAL16_T
+__ENTF90(QMODULOv, qmodulov)(__REAL16_T x, __REAL16_T y)
+{
+  return ENTF90(QMODULOv, qmodulov)(x, y);
 }
 // AOCC End
 

--- a/runtime/include/FuncArgMacros.h
+++ b/runtime/include/FuncArgMacros.h
@@ -76,6 +76,7 @@
 #if defined(DESC_I8)
 #define ENTF90IO(UC, LC) f90io_##LC##_i8
 #define ENTF90(UC, LC) f90_##LC##_i8
+#define __ENTF90(UC, LC) __f90_##LC##_i8
 #define ENTFTN(UC, LC) fort_##LC##_i8
 #define ENTRY(UC, LC) LC##_i8
 #define ENTCRF90IO(UC, LC) crf90io_##LC##_i8 /* FIXME: HPF, delete all with this prefix*/
@@ -86,6 +87,7 @@
 #else /* !defined(DESC_I8) */
 #define ENTF90IO(UC, LC) f90io_##LC
 #define ENTF90(UC, LC) f90_##LC
+#define __ENTF90(UC, LC) __f90_##LC
 #define ENTFTN(UC, LC) fort_##LC
 #define ENTRY(UC, LC) LC
 #define ENTCRF90IO(UC, LC) crf90io_##LC	/* FIXME: HPF, delete all with this prefix*/

--- a/tools/flang1/flang1exe/semfunc.c
+++ b/tools/flang1/flang1exe/semfunc.c
@@ -5451,6 +5451,7 @@ no_const_fold:
    */
 
   func_type = A_INTR;
+  char* rtlFn;
   switch (intast) {
   case I_ICHAR:
     if (count == 2) {
@@ -5461,25 +5462,42 @@ no_const_fold:
   case I_MODULO:
     switch ((int)INTTYPG(sptr)) {
     case DT_SINT:
-      rtlRtn = RTE_imodulov;
+      rtlFn = mkRteRtnNm(RTE_imodulov);
+#if defined(OMP_OFFLOAD_LLVM)
+      if (flg.amdgcn_target) rtlFn ="__f90_imodulov";
+#endif
       break;
     case DT_INT4:
-      rtlRtn = RTE_modulov;
+      rtlFn = mkRteRtnNm(RTE_modulov);
+#if defined(OMP_OFFLOAD_LLVM)
+      if (flg.amdgcn_target) rtlFn ="__f90_modulov";
+#endif
       break;
     case DT_INT8:
-      rtlRtn = RTE_i8modulov;
+      rtlFn = mkRteRtnNm(RTE_i8modulov);
+#if defined(OMP_OFFLOAD_LLVM)
+      if (flg.amdgcn_target) rtlFn ="__f90_i8modulov_i8";
+#endif
       break;
     case DT_REAL4:
-      rtlRtn = RTE_amodulov;
+      rtlFn = mkRteRtnNm(RTE_amodulov);
+#if defined(OMP_OFFLOAD_LLVM)
+      if (flg.amdgcn_target) rtlFn ="__f90_amodulov";
+#endif
       break;
     case DT_REAL8:
-      rtlRtn = RTE_dmodulov;
+      rtlRtn = mkRteRtnNm(RTE_dmodulov);
+#if defined(OMP_OFFLOAD_LLVM)
+      if (flg.amdgcn_target) rtlFn ="__f90_dmodulov";
+#endif
       break;
     case DT_QUAD:
-      rtlRtn = RTE_qmodulov;
-      break;
+      rtlRtn = mkRteRtnNm(RTE_qmodulov);
+#if defined(OMP_OFFLOAD_LLVM)
+      if (flg.amdgcn_target) rtlFn ="__f90_qmodulov";
+#endif
     }
-    fsptr = sym_mkfunc_nodesc(mkRteRtnNm(rtlRtn), (int)INTTYPG(sptr));
+    fsptr = sym_mkfunc_nodesc(rtlFn, (int)INTTYPG(sptr));
     EXTSYMP(sptr, fsptr);
     ELEMENTALP(sptr, 1);
     func_ast = mk_id(fsptr);

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -7800,6 +7800,31 @@ gen_call_expr(int ilix, DTYPE ret_dtype, INSTR_LIST *call_instr, int call_sptr)
         LL_ABI_Info *abi = ll_proto_get_abi(ll_proto_key(sptr));
         abi->is_pure = 0;
       }
+      if (strcmp(SYMNAME(call_sptr),"__f90_imodulov") == 0) {
+         SPTR sptr = mk_prototype_llvm("__f90_imodulov", "", DT_INT, 2, DT_INT, DT_INT);
+         LL_ABI_Info *abi = ll_proto_get_abi(ll_proto_key(sptr));
+         abi->is_pure = 0;
+      }
+      if (strcmp(SYMNAME(call_sptr),"__f90_modulov") == 0) {
+         SPTR sptr = mk_prototype_llvm("__f90_modulov", "", DT_INT, 2, DT_INT, DT_INT);
+         LL_ABI_Info *abi = ll_proto_get_abi(ll_proto_key(sptr));
+         abi->is_pure = 0;
+      }
+      if (strcmp(SYMNAME(call_sptr),"__f90_i8modulov_i8") == 0) {
+         SPTR sptr = mk_prototype_llvm("__f90_i8modulov_i8", "", DT_INT8, 2, DT_INT8, DT_INT8);
+         LL_ABI_Info *abi = ll_proto_get_abi(ll_proto_key(sptr));
+         abi->is_pure = 0;
+      }
+      if (strcmp(SYMNAME(call_sptr),"__f90_amodulov") == 0) {
+         SPTR sptr = mk_prototype_llvm("__f90_amodulov", "", DT_REAL, 2, DT_REAL, DT_REAL);
+         LL_ABI_Info *abi = ll_proto_get_abi(ll_proto_key(sptr));
+         abi->is_pure = 0;
+      }
+      if (strcmp(SYMNAME(call_sptr),"__f90_dmodulov") == 0) {
+         SPTR sptr = mk_prototype_llvm("__f90_dmodulov", "", DT_DBLE, 2, DT_DBLE, DT_DBLE);
+         LL_ABI_Info *abi = ll_proto_get_abi(ll_proto_key(sptr));
+         abi->is_pure = 0;
+      }
   }
   // AOCC End
   if (call_instr == NULL)


### PR DESCRIPTION
Eliminate calls to variadic modulo runtime functions. Variadic functions cause linking errors for OpenMP target pragma if we compile code without inline optimization (O0 level).

OpenMP math library is used for C/C++ and Fortran code. That's why Fortran runtime functions names should not collide with user C++ function names. Adding prefix __ before Fortran runtime functions name eliminates potential conflict with user C++ function names.

Co-Author: Shivarama Rao