### PR TITLE
Handle argument mismatch in OpenMP kernel

### DIFF
--- a/tools/flang2/flang2exe/tgtutil.cpp
+++ b/tools/flang2/flang2exe/tgtutil.cpp
@@ -528,6 +528,13 @@ tgt_target_fill_params(SPTR arg_base_sptr, SPTR arg_size_sptr, SPTR args_sptr,
 #endif
     // AOCC End
 
+    // Flang and Clang can generate OpenMP kernels where number of device
+    // kernel arguments is not equal to number of passed host arguments.
+    // That's why, if given host symbol is not mapped in the target kernel
+    // then we should not mark it as valid param.
+    if (targetinfo->symbols[i].device_sym == NOSYM) {
+        targetinfo->symbols[i].map_type  &= ~(OMP_TGT_MAPTYPE_TARGET_PARAM);
+    }
     ilix = ad4ili(IL_ST, ad_icon(targetinfo->symbols[i].map_type),
                   ad_acon(args_maptypes_sptr, i * TARGET_PTRSIZE), nme_types, MSZ_I8);
     chk_block(ilix);


### PR DESCRIPTION
Clang and Flang can generate the code where the host side can invoke target offloading procedure with more arguments than the number of device OpenMP kernel arguments.

If given host symbol is not mapped into the device symbol then it should be not treated as valid param for offloading.