### PR TITLE
[flang-legacy] - Disable use of libzstd to avoid build failures on RH…

### DIFF
--- a/flang-legacy/llvm-legacy/llvm/CMakeLists.txt
+++ b/flang-legacy/llvm-legacy/llvm/CMakeLists.txt
@@ -491,7 +491,7 @@ endif()
 
 set(LLVM_ENABLE_ZLIB "ON" CACHE STRING "Use zlib for compression/decompression if available. Can be ON, OFF, or FORCE_ON")
 
-set(LLVM_ENABLE_ZSTD "ON" CACHE STRING "Use zstd for compression/decompression if available. Can be ON, OFF, or FORCE_ON")
+set(LLVM_ENABLE_ZSTD "OFF" CACHE STRING "Use zstd for compression/decompression if available. Can be ON, OFF, or FORCE_ON")
 
 set(LLVM_USE_STATIC_ZSTD FALSE CACHE BOOL "Use static version of zstd. Can be TRUE, FALSE")
 


### PR DESCRIPTION
…EL and SLES.