### PR TITLE
Emit locally-scoped imported entities in DISubprogram

### DIFF
--- a/tools/flang2/flang2exe/ll_structure.h
+++ b/tools/flang2/flang2exe/ll_structure.h
@@ -162,6 +162,10 @@ typedef enum LL_IRVersion {
   LL_Version_11_0 = 110,
   LL_Version_12_0 = 120,
   LL_Version_13_0 = 130,
+  LL_Version_14_0 = 140,
+  LL_Version_15_0 = 150,
+  LL_Version_16_0 = 160,
+  LL_Version_17_0 = 170,
   LL_Version_trunk = 1023
 } LL_IRVersion;
 
@@ -488,6 +492,12 @@ INLINE static bool
 ll_feature_no_file_in_namespace(const LL_IRFeatures *feature)
 {
   return feature->version >= LL_Version_5_0;
+}
+
+INLINE static bool
+ll_feature_subprogram_imported_entities(const LL_IRFeatures *feature)
+{
+  return feature->version > LL_Version_17_0;
 }
 
 #else /* !HAVE_INLINE */

--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -1167,7 +1167,7 @@ static const MDTemplate Tmpl_DISubprogram[] = {
 };
 
 static const MDTemplate Tmpl_DISubprogram_90[] = {
-  { "DISubprogram", TF, 18 },
+  { "DISubprogram", TF, 19 },
   { "tag",                      DWTagField, FlgHidden },
   { "file",                     NodeField },
   { "scope",                    NodeField },
@@ -1185,7 +1185,8 @@ static const MDTemplate Tmpl_DISubprogram_90[] = {
   { "templateParams",           NodeField },
   { "declaration",              NodeField },
   { "unit",                     NodeField },
-  { "scopeLine",                UnsignedField }
+  { "scopeLine",                UnsignedField },
+  { "retainedNodes",            NodeField }
 };
 
 static const MDTemplate Tmpl_DISubprogram_70[] = {


### PR DESCRIPTION
This is necessary to generate valid LLVM IR after llvm.org's 06a0ae652.