### PR TITLE
SWDEV-442542 - Remove the setting of compile option "-g" from source code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon -Wno-implicit-function-declaration 
 
 # Add appropriate flags for GCC
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -g -DOMP_OFFLOAD_LLVM -Wno-implicit-function-declaration -Wno-implicit-int -Wno-enum-constexpr-conversion -Wno-incompatible-function-pointer-types -w")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -DOMP_OFFLOAD_LLVM -Wno-implicit-function-declaration -Wno-implicit-int -Wno-enum-constexpr-conversion -Wno-incompatible-function-pointer-types -w")
   option(WITH_WERROR "Compile with '-Werror' C compiler flag" ON)
   if (WITH_WERROR)
 	  # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")


### PR DESCRIPTION
CMake will add the compile option -g based on build type. For Release build type, compile option -g will not get added and this will help in removing the hard coded ROCm path in flang2 binary