### PR TITLE
[flang-legacy][OpenMP] Don't promote int/logical device symbols

### DIFF
--- a/tools/flang2/flang2exe/ompaccel.cpp
+++ b/tools/flang2/flang2exe/ompaccel.cpp
@@ -1159,7 +1159,9 @@ ompaccel_create_device_symbol(SPTR sptr, int count)
 
   // AOCC Begin
   // Interpreting all int args as int64 values
-#ifdef OMP_OFFLOAD_AMD
+  // This is leading to misaligned/oversized atomic ops being executed in
+  // zero-copy mode.  FIXME.
+#if 0 && defined(OMP_OFFLOAD_AMD)
   if (dtype == DT_INT || dtype == DT_BINT || dtype == DT_SINT) {
     dtype = DT_INT8;
   }


### PR DESCRIPTION
The promotion of int/logical device arguments to 64 bits in flang2exe/ompaccel.cpp:ompaccel_create_device_symbol appears to be causing critical problems on AMD GPUs using zero-copy mode (i.e. APUs with XNACK enabled).  This patch disables the promotion.  This appears to fix several OpenMP_VV tests (reduction tests with classic Flang), and doesn't appear to have caused any issues so far in my testing over a range of other testsuites.

However, I am not sure of the original motivation for performing the promotion described above, so the patch may have unwanted side effects elsewhere.

As an example of the problem, consider this fragment:

```
INTEGER FUNCTION test_and()
  LOGICAL:: result

  ! ...

  !$omp target teams distribute map(to: a(1:N)) &
  !$omp& reduction(.and.: result) map(tofrom: &
      !$omp& result)
  DO x = 1, N
  result = a(x) .AND. result
  END DO
END FUNCTION test_and
```

The reduction compiles to something like this:

```
define weak_odr amdgpu_kernel void \
  @__nv_test_target_teams_distribute_device_test_and_TARGET_F1L62_3_ \
  (i64* noalias %Arg_result_0, [1024 x i32]* noalias %Arg_a) !dbg !38 {
...
  %48 = atomicrmw and i64* %Arg_result_0, i64 %47 seq_cst, !dbg !44
...
}
```

Because we promoted the (32-bit) logical 'result' parameter of the offload function to a 64-bit wide type, we perform the atomic operation on a 64-bit quantity.  I suspect we get away with this when the 'result' variable is mapped into target memory because the allocation of device memory allows sufficient alignment and padding for the mapped data.

In the zero-copy case though, the 'result' variable never moves out of host memory.  So in this case the "64-bit" pointer might not be naturally aligned, and/or data beyond the intended variable may participate in the reduction operation.  That may cause aperture violation errors, or other crashes/unpredictable behaviour, respectively.