### PR TITLE
[flang-legacy] - Properly use LIBRARY_PATH if provided

### DIFF
--- a/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -59,7 +59,8 @@ getLinkCommandArgs(Compilation &C, const llvm::opt::ArgList &Args,
                    llvm::opt::ArgStringList &LastLinkArgs, const ToolChain &TC,
                    const llvm::Triple &Triple, llvm::StringRef TargetID,
                    llvm::StringRef OutputFilePrefix, const char *InputFileName,
-                   const RocmInstallationDetector &RocmInstallation);
+                   const RocmInstallationDetector &RocmInstallation,
+                   llvm::opt::ArgStringList &EnvironmentLibraryPaths);
 
 const char *getOptCommandArgs(Compilation &C, const llvm::opt::ArgList &Args,
                               llvm::opt::ArgStringList &OptArgs,

--- a/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
+++ b/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
@@ -229,7 +229,8 @@ const char *amdgpu::dlr::getLinkCommandArgs(
     llvm::opt::ArgStringList &LastLinkArgs, const ToolChain &TC,
     const llvm::Triple &Triple, llvm::StringRef TargetID,
     llvm::StringRef OutputFilePrefix, const char *InputFileName,
-    const RocmInstallationDetector &RocmInstallation) {
+    const RocmInstallationDetector &RocmInstallation,
+    llvm::opt::ArgStringList &EnvironmentLibraryPaths) {
   LastLinkArgs.push_back(Args.MakeArgString(InputFileName));
 
   // Get the environment variable ROCM_LINK_ARGS and add to llvm-link.
@@ -251,12 +252,6 @@ const char *amdgpu::dlr::getLinkCommandArgs(
       LibSuffix.append("/asan");
   }
 
-  // If device debugging turned on, add specially built bc files
-  StringRef libpath = Args.MakeArgString(C.getDriver().Dir + "/../" + LibSuffix);
-  std::string lib_debug_perf_path = FindDebugPerfInLibraryPath(LibSuffix);
-  if (!lib_debug_perf_path.empty())
-    libpath = lib_debug_perf_path;
-
   llvm::SmallVector<std::string, 12> BCLibs;
 
   if (Args.hasFlag(options::OPT_fgpu_sanitize, options::OPT_fno_gpu_sanitize,
@@ -272,8 +267,37 @@ const char *amdgpu::dlr::getLinkCommandArgs(
   }
   StringRef GPUArch = getProcessorFromTargetID(Triple, TargetID);
 
-  BCLibs.push_back(Args.MakeArgString(
-      libpath + "/libomptarget-amdgpu-" + GPUArch + ".bc"));
+  // When the base lib directory is called `lib` we enable
+  // the look-up of the libomptarget bc lib to happen and if not present
+  // where it is expected it means we are using the build tree compiler
+  // not the installed compiler.
+  std::string LibDeviceName = "/libomptarget-amdgpu-" + GPUArch.str() + ".bc";
+
+  // Check if the device library can be found in
+  // one of the LIBRARY_PATH directories.
+  bool EnvOmpLibDeviceFound = false;
+  for (auto &EnvLibraryPath : EnvironmentLibraryPaths) {
+    std::string EnvOmpLibDevice = EnvLibraryPath + LibDeviceName;
+    if (llvm::sys::fs::exists(EnvOmpLibDevice)) {
+      EnvOmpLibDeviceFound = true;
+      BCLibs.push_back(EnvOmpLibDevice);
+      break;
+    }
+  }
+
+  // If LIBRARY_PATH doesn't point to the device library,
+  // then use the default one.
+  if (!EnvOmpLibDeviceFound) {
+    StringRef bc_file_suf = Args.MakeArgString(C.getDriver().Dir + "/../" +
+                                               LibSuffix + LibDeviceName);
+    StringRef bc_file_lib =
+        Args.MakeArgString(C.getDriver().Dir + "/../lib" + LibDeviceName);
+    if (llvm::sys::fs::exists(bc_file_suf))
+      BCLibs.push_back(Args.MakeArgString(bc_file_suf));
+    else if (llvm::sys::fs::exists(bc_file_lib))
+      // In case a LibSuffix version not found, use suffix "lib"
+      BCLibs.push_back(Args.MakeArgString(bc_file_lib));
+    }
 
   // Add the generic set of libraries, OpenMP subset only
   BCLibs.append(amdgpu::dlr::getCommonDeviceLibNames(
@@ -399,12 +423,16 @@ const char *AMDGCN::OpenMPLinker::constructLLVMLinkCommand(
 
   // ---------- llvm-link internalize as-needed -----------
   ArgStringList LastLinkArgs;
+  // Find all directories pointed to by the environment variable
+  // LIBRARY_PATH.
+  ArgStringList EnvLibraryPaths;
+  addDirectoryList(Args, EnvLibraryPaths, "", "LIBRARY_PATH");
   RocmInstallationDetector RocmInstallation(
       C.getDriver(), getToolChain().getTriple(), Args, true, true);
 
   auto OutputFileName = amdgpu::dlr::getLinkCommandArgs(
       C, Args, LastLinkArgs, getToolChain(), getToolChain().getTriple(),
-      TargetID, OutputFilePrefix, PreLinkFileName, RocmInstallation);
+      TargetID, OutputFilePrefix, PreLinkFileName, RocmInstallation, EnvLibraryPaths);
 
   const char *Exec =
       Args.MakeArgString(getToolChain().GetProgramPath("llvm-link"));

--- a/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8926,9 +8926,13 @@ void LinkerWrapper::ConstructOpaqueJob(Compilation &C, const JobAction &JA,
 
     // ---------- Step 3 llvm-link internalize as-needed -----------
     ArgStringList LastLinkArgs;
+    // Find all directories pointed to by the environment variable
+    // LIBRARY_PATH.
+    ArgStringList EnvLibraryPaths;
+    addDirectoryList(Args, EnvLibraryPaths, "", "LIBRARY_PATH");
     auto LinkOutputFileName = amdgpu::dlr::getLinkCommandArgs(
         C, Args, LastLinkArgs, TC, TheTriple, TargetID, OutputFilePrefix,
-        PreLinkFileName, RocmInstallation);
+        PreLinkFileName, RocmInstallation, EnvLibraryPaths);
 
     const char *LinkExec =
         Args.MakeArgString(getToolChain().GetProgramPath("llvm-link"));

--- a/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -900,29 +900,6 @@ void tools::addLTOOptions(const ToolChain &ToolChain, const ArgList &Args,
                          /*IsLTO=*/true, PluginOptPrefix);
 }
 
-std::string tools::FindDebugPerfInLibraryPath(const std::string &RLib) {
-  const char *DirList = ::getenv("LIBRARY_PATH");
-  if (!DirList)
-    return "";
-  StringRef Dirs(DirList);
-  if (Dirs.empty()) // Empty string should not add '.'.
-    return "";
-
-  StringRef::size_type Delim;
-  while ((Delim = Dirs.find(llvm::sys::EnvPathSeparator)) != StringRef::npos) {
-    if (Delim != 0) { // Leading colon.
-      if (Dirs.substr(0, Delim).endswith(RLib))
-        return Dirs.substr(0, Delim).str();
-    }
-    Dirs = Dirs.substr(Delim + 1);
-  }
-  if (!Dirs.empty()) {
-    if (Dirs.endswith(RLib))
-      return Dirs.str();
-  }
-  return "";
-}
-
 void tools::addOpenMPRuntimeSpecificRPath(const ToolChain &TC,
                                           const ArgList &Args,
                                           ArgStringList &CmdArgs) {
@@ -938,11 +915,19 @@ void tools::addOpenMPRuntimeSpecificRPath(const ToolChain &TC,
     if (TC.getSanitizerArgs(Args).needsAsanRt())
       LibSuffix.append("/asan");
   }
-  std::string CandidateRPath = FindDebugPerfInLibraryPath(LibSuffix);
-  std::string CandidateRPathRocmPath = FindDebugPerfInLibraryPath(LibSuffix);
-  if (CandidateRPath.empty())
-    CandidateRPath = D.Dir + "/../" + LibSuffix;
-    CandidateRPathRocmPath = D.Dir + "/../../../" + LibSuffix;
+  // Check if the device library can be found in
+  // one of the LIBRARY_PATH directories.
+  ArgStringList EnvLibraryPaths;
+  addDirectoryList(Args, EnvLibraryPaths, "", "LIBRARY_PATH");
+  for (auto &EnvLibraryPath : EnvLibraryPaths) {
+    if (llvm::sys::fs::exists(EnvLibraryPath)) {
+      CmdArgs.push_back("-rpath");
+      CmdArgs.push_back(Args.MakeArgString(EnvLibraryPath));
+    }
+  }
+
+  std::string CandidateRPath = D.Dir + "/../lib";
+  std::string CandidateRPathRocmPath = D.Dir + "/../../../" + LibSuffix;
 
   if (Args.hasFlag(options::OPT_fopenmp_implicit_rpath,
                    options::OPT_fno_openmp_implicit_rpath, true)) {
@@ -951,17 +936,41 @@ void tools::addOpenMPRuntimeSpecificRPath(const ToolChain &TC,
     SmallString<256> DefaultLibPath =
         llvm::sys::path::parent_path(TC.getDriver().Dir);
     llvm::sys::path::append(DefaultLibPath, CLANG_INSTALL_LIBDIR_BASENAME);
-    CmdArgs.push_back("-rpath");
-    CmdArgs.push_back(Args.MakeArgString(CandidateRPath.c_str()));
-    std::string rocmPath = Args.getLastArgValue(clang::driver::options::OPT_rocm_path_EQ).str();
-    if (rocmPath.size() != 0){
-      rocmPath = rocmPath + "/lib";
+
+    // In case LibSuffix was not built, try lib
+    std::string CandidateRPath_suf = D.Dir + "/../" + LibSuffix;
+    std::string CandidateRPath_lib = D.Dir + "/../lib";
+    if (llvm::sys::fs::exists(CandidateRPath_suf)) {
       CmdArgs.push_back("-rpath");
-      CmdArgs.push_back(Args.MakeArgString(rocmPath.c_str()));
+      CmdArgs.push_back(Args.MakeArgString(CandidateRPath_suf.c_str()));
+    } else if (llvm::sys::fs::exists(CandidateRPath_lib)) {
+      CmdArgs.push_back("-rpath");
+      CmdArgs.push_back(Args.MakeArgString(CandidateRPath_lib.c_str()));
     }
+
+    std::string rocmPath =
+        Args.getLastArgValue(clang::driver::options::OPT_rocm_path_EQ).str();
+    if (rocmPath.size() != 0) {
+      std::string rocmPath_lib = rocmPath + "/lib";
+      std::string rocmPath_suf = rocmPath + "/" + LibSuffix;
+      if (llvm::sys::fs::exists(rocmPath_suf)) {
+        CmdArgs.push_back("-rpath");
+        CmdArgs.push_back(Args.MakeArgString(rocmPath_suf.c_str()));
+      } else if (llvm::sys::fs::exists(rocmPath_lib)) {
+        CmdArgs.push_back("-rpath");
+        CmdArgs.push_back(Args.MakeArgString(rocmPath_lib.c_str()));
+      }
+    }
+
     CmdArgs.push_back("-rpath");
     CmdArgs.push_back(Args.MakeArgString(CandidateRPathRocmPath.c_str()));
+    CmdArgs.push_back("-rpath");
+    CmdArgs.push_back(Args.MakeArgString(CandidateRPath.c_str()));
 
+    if (llvm::find_if(CmdArgs, [](StringRef str) {
+      return !str.compare("--enable-new-dtags");
+      }) == CmdArgs.end())
+      CmdArgs.push_back("--disable-new-dtags");
   }
 }
 

--- a/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/CommonArgs.h
+++ b/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/CommonArgs.h
@@ -132,8 +132,6 @@ void AddAssemblerKPIC(const ToolChain &ToolChain,
                       const llvm::opt::ArgList &Args,
                       llvm::opt::ArgStringList &CmdArgs);
 
-std::string FindDebugPerfInLibraryPath(const std::string &RLib);
-
 void addOpenMPRuntimeSpecificRPath(const ToolChain &TC,
                                    const llvm::opt::ArgList &Args,
                                    llvm::opt::ArgStringList &CmdArgs);

--- a/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/flang-legacy/17.0-4/llvm-legacy/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -568,8 +568,10 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   // Add Fortran runtime libraries
   if (needFortranLibs(D, Args)) {
     ToolChain.AddFortranStdlibLibArgs(Args, CmdArgs);
-    CmdArgs.push_back("-rpath");
-    CmdArgs.push_back(Args.MakeArgString(D.Dir + "/../lib"));
+    if (!Args.hasArg(options::OPT_fopenmp)){
+      CmdArgs.push_back("-rpath");
+      CmdArgs.push_back(Args.MakeArgString(D.Dir + "/../lib"));
+    }
   } else {
     // Claim "no Flang libraries" arguments if any
     for (auto Arg : Args.filtered(options::OPT_noFlangLibs)) {


### PR DESCRIPTION
If LIBRARY_PATH is not a valid path for the bitcode libraries ensure that a fallback location is used. For RPATH we check to see if the openmp library is present before adding it to the final link step.