### PR TITLE
Don't emit nvvm "kernel" annotation for amdgcn targets

### DIFF
--- a/tools/flang2/flang2exe/ll_write.cpp
+++ b/tools/flang2/flang2exe/ll_write.cpp
@@ -2496,11 +2496,15 @@ void ll_build_metadata_device(FILE *out, LLVMModuleRef module)
     if (!function->is_kernel)
     continue;
 
-    mdb = llmd_init(module);
-    llmd_add_value(mdb, ll_get_function_pointer(module, function));
-    llmd_add_string(mdb, "kernel");
-    llmd_add_i32(mdb, 1);
-    ll_extend_named_md_node(module, MD_nvvm_annotations, llmd_finish(mdb));
+#ifdef OMP_OFFLOAD_AMD
+    if (!flg.amdgcn_target) {
+      mdb = llmd_init(module);
+      llmd_add_value(mdb, ll_get_function_pointer(module, function));
+      llmd_add_string(mdb, "kernel");
+      llmd_add_i32(mdb, 1);
+      ll_extend_named_md_node(module, MD_nvvm_annotations, llmd_finish(mdb));
+    }
+#endif
 
     mdb = llmd_init(module);
     llmd_add_value(mdb, ll_get_function_pointer(module, function));


### PR DESCRIPTION
Presence of both nvvm "kernel" annotation and 'amdgpu_kernel' calling convention conflicts with recent llvm commit:

[de7438e47283](https://github.com/llvm/llvm-project/commit/de7438e472839df63e1f10478436c2f15b8e4184) [NVPTX] Auto-Upgrade some nvvm.annotations to attributes ([#119261](https://github.com/llvm/llvm-project/pull/119261))